### PR TITLE
feat(frontend): integrate Lucide React Icons

### DIFF
--- a/.cursor/rules/react-rules.mdc
+++ b/.cursor/rules/react-rules.mdc
@@ -13,3 +13,5 @@ alwaysApply: false
 - Use tanstack query to store backend state.
 - Use type for react props and states. Use interface only for public APIs.
 - Use Apache ECharts for creating charts.
+- Use Lucide React Icons for icon.
+- Use components from `frontend/src/design-system` for building features.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,6 +32,7 @@
         "dayjs": "^1.11.18",
         "echarts": "^6.0.0",
         "lodash.debounce": "^4.0.8",
+        "lucide-react": "^0.554.0",
         "material-symbols": "^0.31.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -5314,6 +5315,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.554.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.554.0.tgz",
+      "integrity": "sha512-St+z29uthEJVx0Is7ellNkgTEhaeSoA42I7JjOCBCrc5X6LYMGSv0P/2uS5HDLTExP5tpiqRD2PyUEOS6s9UXA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/material-symbols": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "dayjs": "^1.11.18",
     "echarts": "^6.0.0",
     "lodash.debounce": "^4.0.8",
+    "lucide-react": "^0.554.0",
     "material-symbols": "^0.31.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/frontend/src/components/Accordion/Accordion.tsx
+++ b/frontend/src/components/Accordion/Accordion.tsx
@@ -1,5 +1,6 @@
 import * as RadixAccordion from "@radix-ui/react-accordion";
 import styles from "./Accordion.module.css";
+import { Icon } from "src/components/design-system/Icon";
 
 export type AccordionItemConfig = {
   value: string;
@@ -24,11 +25,9 @@ export function Accordion({ items, value, onValueChange }: AccordionProps) {
         <RadixAccordion.Header className={styles.accordionHeader}>
           <RadixAccordion.Trigger className={styles.accordionTrigger}>
             {v.trigger}
-            <span
-              className={`material-symbols-outlined ${styles.accordionChevron}`}
-            >
-              keyboard_arrow_down
-            </span>
+            <div className={styles.accordionChevron}>
+              <Icon type="chevron_down" color="default" />
+            </div>
           </RadixAccordion.Trigger>
         </RadixAccordion.Header>
         <RadixAccordion.Content forceMount className={styles.accordionContent}>

--- a/frontend/src/components/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/components/ActionButtons/ActionButtons.tsx
@@ -1,4 +1,5 @@
 import styles from "src/components/ActionButtons/ActionButtons.module.css";
+import { IconButton } from "../design-system";
 
 interface ActionButtonsProps {
   connectionId: string;
@@ -15,33 +16,24 @@ export function ActionButtons({
 }: ActionButtonsProps) {
   return (
     <div className={styles.actionButtonsContainer}>
-      <button
+      <IconButton
+        type="visibility"
+        backgroundColor="transparent"
+        iconColor="grey"
         onClick={() => onViewClick(connectionId)}
-        title="View"
-        className={styles.actionButton}
-      >
-        <span className={`material-symbols-outlined ${styles["button-icon"]}`}>
-          visibility
-        </span>
-      </button>
-      <button
+      />
+      <IconButton
+        type="edit"
+        backgroundColor="transparent"
+        iconColor="grey"
         onClick={() => onEditClick(connectionId)}
-        title="Edit"
-        className={styles.actionButton}
-      >
-        <span className={`material-symbols-outlined ${styles["button-icon"]}`}>
-          edit
-        </span>
-      </button>
-      <button
+      />
+      <IconButton
+        type="delete"
+        backgroundColor="transparent"
+        iconColor="grey"
         onClick={() => onDeleteClick(connectionId)}
-        title="Delete"
-        className={styles.actionButton}
-      >
-        <span className={`material-symbols-outlined ${styles["button-icon"]}`}>
-          delete
-        </span>
-      </button>
+      />
     </div>
   );
 }

--- a/frontend/src/components/ExecuteButton/ExecuteButton.tsx
+++ b/frontend/src/components/ExecuteButton/ExecuteButton.tsx
@@ -1,4 +1,5 @@
 import ExecuteButtonStyles from "src/components/ExecuteButton/ExecuteButton.module.css";
+import { Icon } from "src/components/design-system/Icon";
 
 interface ExecuteButtonProps {
   onClick: () => void;
@@ -7,7 +8,7 @@ interface ExecuteButtonProps {
 export function ExecuteButton({ onClick }: ExecuteButtonProps) {
   return (
     <button className={ExecuteButtonStyles.button} onClick={onClick}>
-      <span className="material-symbols-outlined">play_arrow</span>
+      <Icon type="play" color="default" />
     </button>
   );
 }

--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -1,4 +1,3 @@
-import "material-symbols";
 import NavbarStyles from "src/components/Navbar/Navbar.module.css";
 import { SearchBar } from "src/components/SearchBar";
 

--- a/frontend/src/components/NewAssetButton/NewAssetButton.tsx
+++ b/frontend/src/components/NewAssetButton/NewAssetButton.tsx
@@ -1,4 +1,3 @@
-import "material-symbols";
 import NewAssetButtonStyles from "src/components/NewAssetButton/NewAssetButton.module.css";
 
 export enum ButtonType {

--- a/frontend/src/components/Notebooks/Notebook/CellToolbar/CellToolbar.tsx
+++ b/frontend/src/components/Notebooks/Notebook/CellToolbar/CellToolbar.tsx
@@ -1,7 +1,7 @@
 import ToolbarStyles from "src/css/toolbar.module.css";
 import CellToolbarStyles from "src/components/Notebooks/Notebook/CellToolbar/CellToolbar.module.css";
 import * as Toolbar from "@radix-ui/react-toolbar";
-import { ExecuteButton } from "src/components/ExecuteButton/ExecuteButton";
+import { IconButton } from "src/components/design-system/IconButton/IconButton";
 import { useConnections } from "src/api/connection";
 import { SophoSelect } from "src/components/SophoSelect";
 import { useUpdateCell, useCell } from "src/api/cell";
@@ -83,7 +83,12 @@ export function CellToolbar({ cellId }: { cellId: string }) {
           />
         </Toolbar.Button>
         <Toolbar.Button asChild>
-          <ExecuteButton onClick={() => handleExecuteCell(cellId)} />
+          <IconButton
+            type="play"
+            backgroundColor="transparent"
+            iconColor="green"
+            onClick={() => handleExecuteCell(cellId)}
+          />
         </Toolbar.Button>
       </div>
     </Toolbar.Root>

--- a/frontend/src/components/Notebooks/Notebook/ChartCell/ChartCellToolbar/ChartCellToolbar.tsx
+++ b/frontend/src/components/Notebooks/Notebook/ChartCell/ChartCellToolbar/ChartCellToolbar.tsx
@@ -1,7 +1,7 @@
 import ChartCellToolbarStyles from "src/components/Notebooks/Notebook/ChartCell/ChartCellToolbar/ChartCellToolbar.module.css";
 import ToolbarStyles from "src/css/toolbar.module.css";
 import * as Toolbar from "@radix-ui/react-toolbar";
-import { ExecuteButton } from "src/components/ExecuteButton/ExecuteButton";
+import { IconButton } from "src/components/design-system/IconButton/IconButton";
 import { useConnections } from "src/api/connection";
 import { useUpdateCell, useCell, useExecuteCell } from "src/api/cell";
 import { useEffect, useState } from "react";
@@ -95,7 +95,12 @@ export function ChartCellToolbar({ cellId }: { cellId: string }) {
     <Toolbar.Root className={ToolbarStyles.root} loop>
       <SophoToolTip messageElement={messageElement} children={toolTipTrigger} />
       <Toolbar.Button asChild>
-        <ExecuteButton onClick={handleExecute} />
+        <IconButton
+          type="play"
+          backgroundColor="transparent"
+          iconColor="green"
+          onClick={() => handleExecute()}
+        />
       </Toolbar.Button>
     </Toolbar.Root>
   );

--- a/frontend/src/components/Notebooks/Notebook/NotebookMenuBar/NotebookMenuBar.tsx
+++ b/frontend/src/components/Notebooks/Notebook/NotebookMenuBar/NotebookMenuBar.tsx
@@ -6,6 +6,7 @@ import {
 } from "src/components/Notebooks/Notebook/Cell";
 import { useNotebookStore } from "src/components/Notebooks/store";
 import { useCreateCell } from "src/api/cell";
+import { Icon } from "src/components/design-system/Icon";
 
 type NotebookMenuBarProps = {
   style?: React.CSSProperties;
@@ -29,11 +30,9 @@ export function NotebookMenuBar({ style }: NotebookMenuBarProps = {}) {
     {
       value: "new",
       icon: (
-        <span
-          className={`material-symbols-outlined ${NotebookMenuBarStyles.icon}`}
-        >
-          add
-        </span>
+        <div className={NotebookMenuBarStyles.icon}>
+          <Icon type="add" color="default" />
+        </div>
       ),
       items: [
         {
@@ -56,11 +55,9 @@ export function NotebookMenuBar({ style }: NotebookMenuBarProps = {}) {
     {
       value: "delete",
       icon: (
-        <span
-          className={`material-symbols-outlined ${NotebookMenuBarStyles.icon}`}
-        >
-          remove
-        </span>
+        <div className={NotebookMenuBarStyles.icon}>
+          <Icon type="remove" color="default" />
+        </div>
       ),
       items: [
         {
@@ -76,11 +73,9 @@ export function NotebookMenuBar({ style }: NotebookMenuBarProps = {}) {
     {
       value: "move_up",
       icon: (
-        <span
-          className={`material-symbols-outlined ${NotebookMenuBarStyles.icon}`}
-        >
-          arrow_upward
-        </span>
+        <div className={NotebookMenuBarStyles.icon}>
+          <Icon type="arrow_up" color="default" />
+        </div>
       ),
       items: [
         {
@@ -96,11 +91,9 @@ export function NotebookMenuBar({ style }: NotebookMenuBarProps = {}) {
     {
       value: "move_down",
       icon: (
-        <span
-          className={`material-symbols-outlined ${NotebookMenuBarStyles.icon}`}
-        >
-          arrow_downward
-        </span>
+        <div className={NotebookMenuBarStyles.icon}>
+          <Icon type="arrow_down" color="default" />
+        </div>
       ),
       items: [
         {

--- a/frontend/src/components/Pagination/Pagination.tsx
+++ b/frontend/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,7 @@
 import PaginationStyles from "src/components/Pagination/Pagination.module.css";
 import { Select } from "src/components/Select";
 import { Button } from "src/components/Button";
+import { Icon } from "src/components/design-system/Icon";
 
 export type PaginationProps = {
   totalPages: number;
@@ -78,9 +79,7 @@ function renderEllipsisButton(
       onClick={() => onPageClick(newPage)}
       className={PaginationStyles.paginationButton}
     >
-      <span className={`material-symbols-outlined ${PaginationStyles.icon}`}>
-        more_horiz
-      </span>
+      <Icon type="more_horiz" color="default" />
     </Button>
   );
 }
@@ -101,9 +100,7 @@ function renderPages(
       onClick={() => onPageClick(Math.max(0, currentPage - 1))}
       className={PaginationStyles.paginationButton}
     >
-      <span className={`material-symbols-outlined ${PaginationStyles.icon}`}>
-        chevron_left
-      </span>
+      <Icon type="chevron_left" color="default" />
     </Button>,
     ...pageItems.map((item) =>
       typeof item === "number"
@@ -123,9 +120,7 @@ function renderPages(
       onClick={() => onPageClick(Math.min(totalPages - 1, currentPage + 1))}
       className={PaginationStyles.paginationButton}
     >
-      <span className={`material-symbols-outlined ${PaginationStyles.icon}`}>
-        chevron_right
-      </span>
+      <Icon type="chevron_right" color="default" />
     </Button>,
   ];
 }

--- a/frontend/src/components/Select/Select.tsx
+++ b/frontend/src/components/Select/Select.tsx
@@ -1,5 +1,6 @@
 import * as RadixSelect from "@radix-ui/react-select";
 import SelectStyles from "src/components/Select/Select.module.css";
+import { Icon } from "src/components/design-system/Icon";
 
 export type SelectProps = {
   placeholderText: string;
@@ -29,7 +30,7 @@ export function Select({
     >
       <RadixSelect.ItemText>{option.label}</RadixSelect.ItemText>
       <RadixSelect.ItemIndicator className={SelectStyles.selectItemIndicator}>
-        <span className="material-symbols-outlined">check_small</span>
+        <Icon type="check" color="default" />
       </RadixSelect.ItemIndicator>
     </RadixSelect.Item>
   ));
@@ -40,11 +41,9 @@ export function Select({
           {selectedOption?.label}
         </RadixSelect.Value>
         <RadixSelect.Icon asChild>
-          <span
-            className={`material-symbols-outlined ${SelectStyles.selectIcon}`}
-          >
-            keyboard_arrow_down
-          </span>
+          <div className={SelectStyles.selectIcon}>
+            <Icon type="chevron_down" color="default" />
+          </div>
         </RadixSelect.Icon>
       </RadixSelect.Trigger>
       <RadixSelect.Portal>
@@ -53,7 +52,7 @@ export function Select({
             className={SelectStyles.selectScrollButton}
             asChild
           >
-            <span className="material-symbols-outlined">keyboard_arrow_up</span>
+            <Icon type="chevron_up" color="default" />
           </RadixSelect.ScrollUpButton>
           <RadixSelect.Viewport className={SelectStyles.selectViewport}>
             <RadixSelect.Group>
@@ -67,9 +66,7 @@ export function Select({
             className={SelectStyles.selectScrollButton}
             asChild
           >
-            <span className="material-symbols-outlined">
-              keyboard_arrow_down
-            </span>
+            <Icon type="chevron_down" color="default" />
           </RadixSelect.ScrollDownButton>
           <RadixSelect.Arrow />
         </RadixSelect.Content>

--- a/frontend/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/src/components/Sidebar/Sidebar.module.css
@@ -2,15 +2,17 @@
     /* padding: var(--space-xs); */
     /* margin: var(--space-xs); */
     background-color: var(--color-background);
-    border-radius: var(--border-radius-md);
     box-shadow: var(--shadow);
-    flex: 1;
+    flex: 1.5;
+    max-width: 50px;
+    border-right: var(--border-width-thin) solid var(--color-grey);
 }
 
 .navItems {
     display: flex;
     flex-direction: column;
     gap: var(--space-xxs);
+    align-items: center;
 }
 
 .navItem {

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -1,10 +1,26 @@
 import SidebarStyles from "src/components/Sidebar/Sidebar.module.css";
-import { NavLink } from "react-router";
+import { NavLink, useLocation } from "react-router";
 import { APP_ROUTES } from "src/constants/app_routes";
 import * as NavigationMenu from "@radix-ui/react-navigation-menu";
-import { IconButton } from "src/components/design-system";
+import {
+  IconButtonLink,
+  IconButtonLinkState,
+} from "src/components/design-system";
 
 export function Sidebar() {
+  const location = useLocation();
+
+  const getState = (path: string) => {
+    if (path === APP_ROUTES.INDEX) {
+      return location.pathname === APP_ROUTES.INDEX
+        ? IconButtonLinkState.ACTIVE
+        : IconButtonLinkState.INACTIVE;
+    }
+    return location.pathname.startsWith(path)
+      ? IconButtonLinkState.ACTIVE
+      : IconButtonLinkState.INACTIVE;
+  };
+
   return (
     <div className={SidebarStyles.sidebar}>
       <NavigationMenu.Root>
@@ -19,36 +35,33 @@ export function Sidebar() {
           <NavigationMenu.Item className={SidebarStyles.navItem}>
             <NavigationMenu.Link asChild>
               <NavLink to={APP_ROUTES.INDEX} className={SidebarStyles.link}>
-                <IconButton
+                <IconButtonLink
                   type="home"
-                  backgroundColor="white"
-                  iconColor="black"
-                  tooltip={{ text: "Home", direction: "top" }}
-                ></IconButton>
+                  state={getState(APP_ROUTES.INDEX)}
+                  tooltip={{ text: "Home", direction: "right" }}
+                />
               </NavLink>
             </NavigationMenu.Link>
           </NavigationMenu.Item>
           <NavigationMenu.Item className={SidebarStyles.navItem}>
             <NavigationMenu.Link asChild>
               <NavLink to={APP_ROUTES.NOTEBOOKS} className={SidebarStyles.link}>
-                <IconButton
-                  type="book_2"
-                  backgroundColor="white"
-                  iconColor="black"
-                  tooltip={{ text: "Notebooks", direction: "top" }}
-                ></IconButton>
+                <IconButtonLink
+                  type="book"
+                  state={getState(APP_ROUTES.NOTEBOOKS)}
+                  tooltip={{ text: "Notebooks", direction: "right" }}
+                />
               </NavLink>
             </NavigationMenu.Link>
           </NavigationMenu.Item>
           <NavigationMenu.Item className={SidebarStyles.navItem}>
             <NavigationMenu.Link asChild>
               <NavLink to={APP_ROUTES.SETTINGS} className={SidebarStyles.link}>
-                <IconButton
+                <IconButtonLink
                   type="settings"
-                  backgroundColor="white"
-                  iconColor="black"
-                  tooltip={{ text: "Settings", direction: "top" }}
-                ></IconButton>
+                  state={getState(APP_ROUTES.SETTINGS)}
+                  tooltip={{ text: "Settings", direction: "right" }}
+                />
               </NavLink>
             </NavigationMenu.Link>
           </NavigationMenu.Item>

--- a/frontend/src/components/SophoDialog/SophoDialog.tsx
+++ b/frontend/src/components/SophoDialog/SophoDialog.tsx
@@ -43,8 +43,8 @@ export function SophoDialog({
                   <Dialog.Close asChild>
                     <IconButton
                       type="close"
-                      backgroundColor="white"
-                      iconColor="black"
+                      backgroundColor="transparent"
+                      iconColor="grey"
                       onClick={handleDialogClose}
                       aria-label="Close"
                     />

--- a/frontend/src/components/SophoSelect/SophoSelect.tsx
+++ b/frontend/src/components/SophoSelect/SophoSelect.tsx
@@ -1,6 +1,7 @@
 import * as Select from "@radix-ui/react-select";
 import * as Toolbar from "@radix-ui/react-toolbar";
 import SophoSelectStyles from "src/components/SophoSelect/SophoSelect.module.css";
+import { Icon } from "src/components/design-system/Icon";
 
 type SophoSelectProps = {
   groupName: string;
@@ -34,7 +35,7 @@ export function SophoSelect({
     >
       <Select.ItemText>{option.label}</Select.ItemText>
       <Select.ItemIndicator className={SophoSelectStyles.selectItemIndicator}>
-        <span className="material-symbols-outlined">check_small</span>
+        <Icon type="check" color="default" />
       </Select.ItemIndicator>
     </Select.Item>
   ));
@@ -50,9 +51,9 @@ export function SophoSelect({
             {initialValue?.label}
           </Select.Value>
           <Select.Icon className={SophoSelectStyles.selectIcon} asChild>
-            <span className="material-symbols-outlined">
-              keyboard_arrow_down
-            </span>
+            <div>
+              <Icon type="chevron_down" color="default" />
+            </div>
           </Select.Icon>
         </Select.Trigger>
       </Toolbar.Button>
@@ -62,7 +63,7 @@ export function SophoSelect({
             className={SophoSelectStyles.selectScrollButton}
             asChild
           >
-            <span className="material-symbols-outlined">keyboard_arrow_up</span>
+            <Icon type="chevron_up" color="default" />
           </Select.ScrollUpButton>
           <Select.Viewport className={SophoSelectStyles.selectViewport}>
             <Select.Group>
@@ -76,9 +77,7 @@ export function SophoSelect({
             className={SophoSelectStyles.selectScrollButton}
             asChild
           >
-            <span className="material-symbols-outlined">
-              keyboard_arrow_down
-            </span>
+            <Icon type="chevron_down" color="default" />
           </Select.ScrollDownButton>
           <Select.Arrow />
         </Select.Content>

--- a/frontend/src/components/design-system/Icon/Icon.module.css
+++ b/frontend/src/components/design-system/Icon/Icon.module.css
@@ -1,5 +1,20 @@
+.icon {
+    flex-shrink: 0;
+    max-width: none;
+    width: 20px;
+    height: 20px;
+}
+
 .accent {
     color: var(--color-accent);
+}
+
+.accent:hover {
+    color: var(--color-accent-dark-1);
+}
+
+.accent:active {
+    color: var(--color-accent-light-1);
 }
 
 .white {
@@ -7,17 +22,38 @@
 }
 
 .white:hover {
-    background-color: var(--color-accent-dark-1);
+    color: var(--color-background-dark-1);
 }
 
 .white:active {
-    background-color: var(--color-accent-light-1);
+    color: var(--color-background-light-1);
 }
 
-.black {
-    color: var(--color-foreground);
+.grey {
+    color: var(--color-grey-dark-2);
 }
 
-span {
-    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 48;
+.grey:hover {
+    color: var(--color-grey-dark-3);
+}
+
+.grey:active {
+    color: var(--color-grey-dark-1);
+}
+
+.green {
+    fill: var(--color-green-dark-2);
+    stroke-width: 0;
+}
+
+.green:hover {
+    fill: var(--color-green-dark-3);
+}
+
+.green:active {
+    color: var(--color-green-dark-1);
+}
+
+.filled {
+    font-variation-settings: 'FILL' 1;
 }

--- a/frontend/src/components/design-system/Icon/Icon.tsx
+++ b/frontend/src/components/design-system/Icon/Icon.tsx
@@ -1,14 +1,66 @@
 import { IconColor, IconType } from "src/components/design-system/datatypes";
 import styles from "src/components/design-system/Icon/Icon.module.css";
+import {
+  Plus,
+  Home,
+  BookOpen,
+  Settings,
+  X,
+  ArrowLeftRight,
+  ArrowUpDown,
+  Eye,
+  Pencil,
+  Trash2,
+  Play,
+  Minus,
+  ArrowUp,
+  ArrowDown,
+  MoreHorizontal,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  ChevronUp,
+  Check,
+  LucideIcon,
+} from "lucide-react";
+
+const iconMap: Record<IconType, LucideIcon> = {
+  add: Plus,
+  home: Home,
+  book: BookOpen,
+  settings: Settings,
+  close: X,
+  swap_horiz: ArrowLeftRight,
+  swap_vert: ArrowUpDown,
+  visibility: Eye,
+  edit: Pencil,
+  delete: Trash2,
+  play: Play,
+  remove: Minus,
+  arrow_up: ArrowUp,
+  arrow_down: ArrowDown,
+  more_horiz: MoreHorizontal,
+  chevron_left: ChevronLeft,
+  chevron_right: ChevronRight,
+  chevron_down: ChevronDown,
+  chevron_up: ChevronUp,
+  check: Check,
+};
 
 type IconProps = {
   type: IconType;
   color: IconColor;
+  strokeWidth?: number;
 };
 
-export function Icon({ type, color }: IconProps) {
+export function Icon({ type, color, strokeWidth = 2.25 }: IconProps) {
   const className = styles[color];
+  const IconComponent = iconMap[type];
   return (
-    <span className={`material-symbols-outlined ${className}`}>{type}</span>
+    <IconComponent
+      size={20}
+      className={`${styles.icon} ${className}`}
+      strokeWidth={strokeWidth}
+    />
   );
 }

--- a/frontend/src/components/design-system/IconButton/IconButton.module.css
+++ b/frontend/src/components/design-system/IconButton/IconButton.module.css
@@ -2,11 +2,12 @@
     padding: var(--space-xs);
     border-radius: var(--border-radius-full);
     display: flex;
-    align-items: center;
+    cursor: pointer;
+    transition: transform 0.1s ease-out;
 }
 
 .button:active {
-    transform: scale(0.95);
+    transform: scale(0.9);
 }
 
 .accent {
@@ -14,7 +15,7 @@
 }
 
 .white {
-    color: var(--color-background);
+    background-color: var(--color-background);
 }
 
 .white:hover {
@@ -23,4 +24,20 @@
 
 .white:active {
     background-color: var(--color-grey-light-1);
+}
+
+.grey {
+    background-color: var(--color-background);
+}
+
+.grey:hover {
+    background-color: var(--color-grey);
+}
+
+.grey:active {
+    background-color: var(--color-grey-light-1);
+}
+
+.transparent {
+    background-color: transparent;
 }

--- a/frontend/src/components/design-system/IconButtonLink/IconButtonLink.module.css
+++ b/frontend/src/components/design-system/IconButtonLink/IconButtonLink.module.css
@@ -1,0 +1,38 @@
+.button {
+    padding: var(--space-xs);
+    border-radius: var(--border-radius-full);
+    display: flex;
+    cursor: pointer;
+    transition: transform 0.1s ease-out, background-color 0.2s ease-out;
+    border: none;
+    align-items: center;
+    align-content: center;
+}
+
+.button:active {
+    transform: scale(0.9);
+}
+
+.active {
+    background-color: var(--color-grey-dark-1);
+}
+
+.active:hover {
+    background-color: var(--color-grey-dark-2);
+}
+
+.active:active {
+    background-color: var(--color-grey-dark-3);
+}
+
+.inactive {
+    background-color: var(--color-background);
+}
+
+.inactive:hover {
+    background-color: var(--color-grey-light-1);
+}
+
+.inactive:active {
+    background-color: var(--color-grey);
+}

--- a/frontend/src/components/design-system/IconButtonLink/IconButtonLink.tsx
+++ b/frontend/src/components/design-system/IconButtonLink/IconButtonLink.tsx
@@ -1,0 +1,43 @@
+import { IconType } from "src/components/design-system/datatypes";
+import styles from "src/components/design-system/IconButtonLink/IconButtonLink.module.css";
+import { Icon } from "src/components/design-system/Icon";
+import { SophoToolTip } from "src/components/SophoToolTip/SophoToolTip";
+
+export enum State {
+  ACTIVE = "ACTIVE",
+  DISABLED = "DISABLED",
+  INACTIVE = "INACTIVE",
+}
+
+type IconButtonLinkProps = {
+  state: State;
+  type: IconType;
+  tooltip?: {
+    text: string;
+    direction?: "top" | "right" | "bottom" | "left";
+  };
+};
+
+export function IconButtonLink({ state, type, tooltip }: IconButtonLinkProps) {
+  const iconColor = state === State.ACTIVE ? "white" : "grey";
+  const className = styles[state.toLowerCase()];
+
+  const button = (
+    <button className={`${styles.button} ${className}`}>
+      <Icon type={type} color={iconColor}></Icon>
+    </button>
+  );
+
+  if (tooltip) {
+    return (
+      <SophoToolTip
+        messageElement={tooltip.text}
+        tooltipSide={tooltip.direction || "top"}
+      >
+        {button}
+      </SophoToolTip>
+    );
+  }
+
+  return button;
+}

--- a/frontend/src/components/design-system/IconButtonLink/index.tsx
+++ b/frontend/src/components/design-system/IconButtonLink/index.tsx
@@ -1,0 +1,1 @@
+export { IconButtonLink, State } from "./IconButtonLink";

--- a/frontend/src/components/design-system/Select/Select.tsx
+++ b/frontend/src/components/design-system/Select/Select.tsx
@@ -1,5 +1,6 @@
 import * as RadixSelect from "@radix-ui/react-select";
 import SelectStyles from "src/components/design-system/Select/Select.module.css";
+import { Icon } from "src/components/design-system/Icon";
 
 export type SelectProps = {
   placeholderText: string;
@@ -29,7 +30,7 @@ export function Select({
     >
       <RadixSelect.ItemText>{option.label}</RadixSelect.ItemText>
       <RadixSelect.ItemIndicator className={SelectStyles.selectItemIndicator}>
-        <span className="material-symbols-outlined">check_small</span>
+        <Icon type="check" color="default" />
       </RadixSelect.ItemIndicator>
     </RadixSelect.Item>
   ));
@@ -40,11 +41,9 @@ export function Select({
           {selectedOption?.label}
         </RadixSelect.Value>
         <RadixSelect.Icon asChild>
-          <span
-            className={`material-symbols-outlined ${SelectStyles.selectIcon}`}
-          >
-            keyboard_arrow_down
-          </span>
+          <div className={SelectStyles.selectIcon}>
+            <Icon type="chevron_down" color="default" />
+          </div>
         </RadixSelect.Icon>
       </RadixSelect.Trigger>
       <RadixSelect.Portal>
@@ -53,7 +52,7 @@ export function Select({
             className={SelectStyles.selectScrollButton}
             asChild
           >
-            <span className="material-symbols-outlined">keyboard_arrow_up</span>
+            <Icon type="chevron_up" color="default" />
           </RadixSelect.ScrollUpButton>
           <RadixSelect.Viewport className={SelectStyles.selectViewport}>
             <RadixSelect.Group>
@@ -67,9 +66,7 @@ export function Select({
             className={SelectStyles.selectScrollButton}
             asChild
           >
-            <span className="material-symbols-outlined">
-              keyboard_arrow_down
-            </span>
+            <Icon type="chevron_down" color="default" />
           </RadixSelect.ScrollDownButton>
           <RadixSelect.Arrow />
         </RadixSelect.Content>

--- a/frontend/src/components/design-system/datatypes.tsx
+++ b/frontend/src/components/design-system/datatypes.tsx
@@ -13,16 +13,32 @@ export type IconColor =
   | "default"
   | "info"
   | "error"
-  | "warning";
+  | "warning"
+  | "green"
+  | "grey"
+  | "transparent";
 
 export type IconType =
   | "add"
   | "home"
-  | "book_2"
+  | "book"
   | "settings"
   | "close"
   | "swap_horiz"
-  | "swap_vert";
+  | "swap_vert"
+  | "visibility"
+  | "edit"
+  | "delete"
+  | "play"
+  | "remove"
+  | "arrow_up"
+  | "arrow_down"
+  | "more_horiz"
+  | "chevron_left"
+  | "chevron_right"
+  | "chevron_down"
+  | "chevron_up"
+  | "check";
 
 export type FlexValue = "grow" | "shrink" | "none" | NumberString;
 

--- a/frontend/src/components/design-system/index.tsx
+++ b/frontend/src/components/design-system/index.tsx
@@ -1,4 +1,8 @@
 export { IconButton } from "src/components/design-system/IconButton";
+export {
+  IconButtonLink,
+  State as IconButtonLinkState,
+} from "src/components/design-system/IconButtonLink";
 export { Icon } from "src/components/design-system/Icon";
 export { Heading } from "src/components/design-system/Heading";
 export { Form } from "src/components/design-system/Form";


### PR DESCRIPTION
- Add Lucide React Icons for improved iconography.
- Update various components (Accordion, ActionButtons, ExecuteButton, Navbar, etc.) to use the new Icon component from the design system.
- Replace material symbols with the new icon system for consistency.
- Enhance Sidebar and other components to utilize IconButtonLink for better navigation state management.
- Add IconButtonLink design system component for buttons with icons that redirect to a link, and use it in the Sidebar.

Refs: #33