### PR TITLE
feat(frontend): add form error banner

### DIFF
--- a/frontend/src/components/ActionButtons/ActionButtons.tsx
+++ b/frontend/src/components/ActionButtons/ActionButtons.tsx
@@ -19,19 +19,19 @@ export function ActionButtons({
       <IconButton
         type="visibility"
         backgroundColor="transparent"
-        iconColor="grey"
+        iconColor="black"
         onClick={() => onViewClick(connectionId)}
       />
       <IconButton
         type="edit"
         backgroundColor="transparent"
-        iconColor="grey"
+        iconColor="black"
         onClick={() => onEditClick(connectionId)}
       />
       <IconButton
         type="delete"
         backgroundColor="transparent"
-        iconColor="grey"
+        iconColor="black"
         onClick={() => onDeleteClick(connectionId)}
       />
     </div>

--- a/frontend/src/components/Notebooks/Notebook/ChartCell/CellEditor/CellEditor.module.css
+++ b/frontend/src/components/Notebooks/Notebook/ChartCell/CellEditor/CellEditor.module.css
@@ -15,7 +15,7 @@
 .formField {
     display: flex;
     flex-direction: column;
-    gap: var(--space-md);
+    gap: var(--space-2xs);
 }
 
 .accordionTriggerHeading {

--- a/frontend/src/components/Sidebar/Sidebar.module.css
+++ b/frontend/src/components/Sidebar/Sidebar.module.css
@@ -11,7 +11,7 @@
 .navItems {
     display: flex;
     flex-direction: column;
-    gap: var(--space-xxs);
+    gap: 0;
     align-items: center;
 }
 

--- a/frontend/src/components/design-system/BannerSlim/BannerSlim.module.css
+++ b/frontend/src/components/design-system/BannerSlim/BannerSlim.module.css
@@ -1,0 +1,5 @@
+.iconWrapper {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+}

--- a/frontend/src/components/design-system/BannerSlim/BannerSlim.tsx
+++ b/frontend/src/components/design-system/BannerSlim/BannerSlim.tsx
@@ -1,0 +1,32 @@
+import { Flex, Icon } from "src/components/design-system";
+import { Text } from "src/components/design-system";
+import styles from "./BannerSlim.module.css";
+
+type BannerSlimProps = {
+  type: "error" | "info";
+  message: string | undefined;
+};
+
+export function BannerSlim({ type, message }: BannerSlimProps) {
+  if (!message) {
+    return null;
+  }
+  return (
+    <Flex
+      color="error"
+      borderRadius="lg"
+      paddingX="xs"
+      paddingY="xs"
+      alignItems="center"
+      alignContent="center"
+      gap="xs"
+    >
+      <span className={styles.iconWrapper}>
+        <Icon type="triangle_alert" color="error"></Icon>
+      </span>
+      <Text color="default" fontSize="sm">
+        {message}
+      </Text>
+    </Flex>
+  );
+}

--- a/frontend/src/components/design-system/BannerSlim/index.tsx
+++ b/frontend/src/components/design-system/BannerSlim/index.tsx
@@ -1,0 +1,1 @@
+export { BannerSlim } from "src/components/design-system/BannerSlim/BannerSlim";

--- a/frontend/src/components/design-system/Box/Box.module.css
+++ b/frontend/src/components/design-system/Box/Box.module.css
@@ -1,3 +1,7 @@
 .default {
     background-color: var(--color-background);
 }
+
+.error {
+    background-color: var(--color-red-light-5);
+}

--- a/frontend/src/components/design-system/Box/Box.tsx
+++ b/frontend/src/components/design-system/Box/Box.tsx
@@ -2,14 +2,12 @@ import styles from "src/components/design-system/Box/Box.module.css";
 import type {
   SharedLayoutProps,
   BoxElement,
-  ColorVariant,
   Display,
 } from "src/components/design-system/datatypes";
 import { getSharedLayoutStyles } from "src/components/design-system/utils";
 
 export type BoxProps = SharedLayoutProps & {
   as?: BoxElement;
-  color?: ColorVariant;
   display?: Display;
   children: React.ReactNode;
 };

--- a/frontend/src/components/design-system/Form/Form.module.css
+++ b/frontend/src/components/design-system/Form/Form.module.css
@@ -1,7 +1,7 @@
 .formRoot {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: var(--space-lg);
   width: 100%;
 }
 
@@ -69,14 +69,13 @@
 
 .formMessage {
   color: var(--color-red-dark-2);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
 }
 
 .formButtonRow {
   display: flex;
   justify-content: flex-end;
   gap: var(--space-md);
-  margin-top: var(--space-xs);
-  padding-top: var(--space-sm);
+  /* margin-top: var(--space-xs);
+  padding-top: var(--space-sm); */
 }
-

--- a/frontend/src/components/design-system/Form/Form.tsx
+++ b/frontend/src/components/design-system/Form/Form.tsx
@@ -10,6 +10,9 @@ import {
   findAccordionsWithInvalidFields,
 } from "./utils/validation";
 import { deriveDefaultValues, convertValuesToFormData } from "./utils/values";
+import { BannerSlim } from "../BannerSlim";
+import { revalidateLogic, useStore } from "@tanstack/react-form";
+import { getErrorSummary } from "./utils/errorSummary";
 
 type FormProps = {
   fields: FormField[];
@@ -51,8 +54,12 @@ export function Form({
       const formData = convertValuesToFormData(value as Record<string, any>);
       onSubmitCallback(formData);
     },
+    validationLogic: revalidateLogic({
+      mode: "submit",
+      modeAfterSubmission: "change",
+    }),
     validators: {
-      onSubmit({ value }) {
+      onDynamic({ value }) {
         const { errorMap, invalidFields } = validateFields(
           fields,
           value as Record<string, any>
@@ -70,11 +77,10 @@ export function Form({
           setAccordionState(newAccordionState);
 
           return {
-            form: "Invalid data",
+            form: "form validation",
             fields: errorMap,
           };
         }
-
         return undefined;
       },
     },
@@ -94,8 +100,14 @@ export function Form({
     }),
   });
 
+  const formFieldMeta = useStore(form.store, (state) => state.fieldMeta);
+
   return (
     <div className={`${FormStyles.formRoot} ${rootStyleClass || ""}`}>
+      <BannerSlim
+        type="error"
+        message={getErrorSummary(formFieldMeta, fields)}
+      />
       <form.AppForm>
         <div className={fieldsContainerStyleClass || FormStyles.formElements}>
           {fields.map((field) => (

--- a/frontend/src/components/design-system/Form/SubscribeButton.tsx
+++ b/frontend/src/components/design-system/Form/SubscribeButton.tsx
@@ -14,7 +14,7 @@ export function SubscribeButton({ label }: { label: string }) {
           backgroundColor="accent"
           size="sm"
           shape="rectangle"
-          type="button"
+          type="submit"
           disabled={isSubmitting}
         />
       )}

--- a/frontend/src/components/design-system/Form/utils/errorSummary.tsx
+++ b/frontend/src/components/design-system/Form/utils/errorSummary.tsx
@@ -1,0 +1,30 @@
+import {
+  FormField,
+  FormFieldType,
+} from "src/components/design-system/Form/types";
+
+export function getErrorSummary(
+  formFieldMeta: any,
+  fields: FormField[]
+): string | undefined {
+  let invalidCount = 0;
+
+  const checkField = (field: FormField) => {
+    const fieldMeta = formFieldMeta[field.key];
+    if (fieldMeta && fieldMeta.isValid === false) {
+      invalidCount++;
+    }
+
+    if (field.type === FormFieldType.COLLAPSIBLE && field.collapsibleConfig) {
+      field.collapsibleConfig.fields.forEach(checkField);
+    }
+  };
+
+  fields.forEach(checkField);
+
+  if (invalidCount > 0) {
+    return `${invalidCount} invalid field${invalidCount === 1 ? "" : "s"} need${invalidCount === 1 ? "s" : ""} to be fixed below`;
+  }
+
+  return undefined;
+}

--- a/frontend/src/components/design-system/Icon/Icon.module.css
+++ b/frontend/src/components/design-system/Icon/Icon.module.css
@@ -54,6 +54,18 @@
     color: var(--color-green-dark-1);
 }
 
+.black {
+    color: var(--color-foreground-light-3);
+}
+
+.black:hover {
+    color: var(--color-foreground);
+}
+
+.black:active {
+    color: var(--color-foreground-light-5);
+}
+
 .filled {
     font-variation-settings: 'FILL' 1;
 }

--- a/frontend/src/components/design-system/Icon/Icon.tsx
+++ b/frontend/src/components/design-system/Icon/Icon.tsx
@@ -21,6 +21,7 @@ import {
   ChevronDown,
   ChevronUp,
   Check,
+  TriangleAlert,
   LucideIcon,
 } from "lucide-react";
 
@@ -45,6 +46,7 @@ const iconMap: Record<IconType, LucideIcon> = {
   chevron_down: ChevronDown,
   chevron_up: ChevronUp,
   check: Check,
+  triangle_alert: TriangleAlert,
 };
 
 type IconProps = {

--- a/frontend/src/components/design-system/IconButtonLink/IconButtonLink.tsx
+++ b/frontend/src/components/design-system/IconButtonLink/IconButtonLink.tsx
@@ -19,7 +19,7 @@ type IconButtonLinkProps = {
 };
 
 export function IconButtonLink({ state, type, tooltip }: IconButtonLinkProps) {
-  const iconColor = state === State.ACTIVE ? "white" : "grey";
+  const iconColor = state === State.ACTIVE ? "white" : "black";
   const className = styles[state.toLowerCase()];
 
   const button = (

--- a/frontend/src/components/design-system/Select/Select.module.css
+++ b/frontend/src/components/design-system/Select/Select.module.css
@@ -16,8 +16,7 @@
 	font-size: var(--font-size-sm);
 	background-color: var(--color-background);
 	color: var(--color-foreground);
-	/* box-shadow: var(--shadow); */
-	border: var(--border-width-medium) solid var(--color-grey);
+	border: var(--border-width-medium) solid var(--color-grey-dark-2);
 	overflow: hidden;
 }
 

--- a/frontend/src/components/design-system/Text/Text.module.css
+++ b/frontend/src/components/design-system/Text/Text.module.css
@@ -13,3 +13,47 @@
 .disabled {
     color: var(--font-color-disabled);
 }
+
+.error {
+    color: var(--color-red);
+}
+
+.fontSize-xs {
+    font-size: var(--font-size-xs);
+}
+
+.fontSize-sm {
+    font-size: var(--font-size-sm);
+}
+
+.fontSize-base {
+    font-size: var(--font-size-base);
+}
+
+.fontSize-lg {
+    font-size: var(--font-size-lg);
+}
+
+.fontSize-xl {
+    font-size: var(--font-size-xl);
+}
+
+.fontSize-2xl {
+    font-size: var(--font-size-2xl);
+}
+
+.fontSize-3xl {
+    font-size: var(--font-size-3xl);
+}
+
+.fontSize-4xl {
+    font-size: var(--font-size-4xl);
+}
+
+.fontSize-5xl {
+    font-size: var(--font-size-5xl);
+}
+
+.fontSize-6xl {
+    font-size: var(--font-size-6xl);
+}

--- a/frontend/src/components/design-system/Text/Text.tsx
+++ b/frontend/src/components/design-system/Text/Text.tsx
@@ -10,11 +10,29 @@ type TextProps = {
     | "error"
     | "success"
     | "warning";
+  fontSize?:
+    | "xs"
+    | "sm"
+    | "base"
+    | "lg"
+    | "xl"
+    | "2xl"
+    | "3xl"
+    | "4xl"
+    | "5xl"
+    | "6xl";
   children: React.ReactNode;
 };
 
-export function Text({ as = "span", children, color = "default" }: TextProps) {
+export function Text({
+  as = "span",
+  children,
+  color = "default",
+  fontSize,
+}: TextProps) {
   const Component = as;
-  const className = styles[color];
-  return <Component className={className}>{children}</Component>;
+  const classNames = [styles[color], fontSize && styles[`fontSize-${fontSize}`]]
+    .filter(Boolean)
+    .join(" ");
+  return <Component className={classNames}>{children}</Component>;
 }

--- a/frontend/src/components/design-system/datatypes.tsx
+++ b/frontend/src/components/design-system/datatypes.tsx
@@ -6,6 +6,8 @@ export type ButtonType = "submit" | "button";
 
 export type ButtonEmphasis = "primary" | "secondary" | "tertiary";
 
+export type BorderRadius = "sm" | "md" | "lg" | "xl" | "2xl" | "full";
+
 export type IconColor =
   | "accent"
   | "white"
@@ -38,7 +40,8 @@ export type IconType =
   | "chevron_right"
   | "chevron_down"
   | "chevron_up"
-  | "check";
+  | "check"
+  | "triangle_alert";
 
 export type FlexValue = "grow" | "shrink" | "none" | NumberString;
 
@@ -60,6 +63,15 @@ export type AlignItems =
   | "center"
   | "stretch"
   | "baseline";
+
+export type AlignContent =
+  | "flex-start"
+  | "flex-end"
+  | "center"
+  | "space-between"
+  | "space-around"
+  | "space-evenly"
+  | "stretch";
 
 export type ColorVariant = "default" | "info" | "error" | "warning";
 
@@ -90,6 +102,8 @@ export type BoxElement =
   | "summary";
 
 export type SharedLayoutProps = {
+  borderRadius?: BorderRadius;
+  color?: ColorVariant;
   direction?: Direction;
   gap?: SpacingSize;
   paddingX?: SpacingSize;
@@ -102,6 +116,7 @@ export type SharedLayoutProps = {
   overflow?: OverflowValue;
   justifyContent?: JustifyContent;
   alignItems?: AlignItems;
+  alignContent?: AlignContent;
   top?: SpacingValue;
   bottom?: SpacingValue;
   left?: SpacingValue;

--- a/frontend/src/components/design-system/index.tsx
+++ b/frontend/src/components/design-system/index.tsx
@@ -9,3 +9,4 @@ export { Form } from "src/components/design-system/Form";
 export { Select } from "src/components/design-system/Select";
 export { Flex } from "src/components/design-system/Flex/Flex";
 export { Text } from "src/components/design-system/Text";
+export { BannerSlim } from "src/components/design-system/BannerSlim";

--- a/frontend/src/components/design-system/utils.tsx
+++ b/frontend/src/components/design-system/utils.tsx
@@ -88,6 +88,10 @@ function getSizeValue(
   return value;
 }
 
+function getBorderRadius(borderRadius: string) {
+  return getCSSVariable(`--border-radius-${borderRadius}`);
+}
+
 export function getSharedLayoutStyles(
   props: SharedLayoutProps
 ): React.CSSProperties {
@@ -104,6 +108,7 @@ export function getSharedLayoutStyles(
     overflow,
     justifyContent,
     alignItems,
+    alignContent,
     position,
     top,
     bottom,
@@ -112,6 +117,7 @@ export function getSharedLayoutStyles(
     zIndex,
     height,
     width,
+    borderRadius,
   } = props;
 
   const gapSize = gap ? getCSSVariable(`--space-${gap}`) : undefined;
@@ -154,6 +160,8 @@ export function getSharedLayoutStyles(
     ...(width !== undefined && { width: getSizeValue(width) }),
     ...(justifyContent && { justifyContent }),
     ...(alignItems && { alignItems }),
+    ...(alignContent && { alignContent }),
+    ...(borderRadius && { borderRadius: getBorderRadius(borderRadius) }),
     ...getFlexStyles(flex),
     ...getOverflowStyles(overflow),
   };

--- a/frontend/src/css/index.css
+++ b/frontend/src/css/index.css
@@ -86,7 +86,7 @@ button {
   --color-background-dark-1: hsla(249, 99%, 99%, 1);
   --color-background-dark-2: hsla(249, 99%, 90%, 1);
 
-  --color-foreground: #000000;
+  --color-foreground: hsl(0, 0%, 0%, 1);
   --color-foreground-light-1: hsl(0, 0%, 5%, 1);
   --color-foreground-light-2: hsl(0, 0%, 7.5%, 1);
   --color-foreground-light-3: hsl(0, 0%, 10%, 1);
@@ -117,6 +117,12 @@ button {
   --color-green-dark-5: hsl(84, 73%, 12%, 1);
   --color-green-dark-6: hsl(84, 67%, 5%, 1);
 
+  --color-red-light-1: hsl(0, 80%, 70%, 1);
+  --color-red-light-2: hsl(0, 75%, 80%, 1);
+  --color-red-light-3: hsl(0, 70%, 85%, 1);
+  --color-red-light-4: hsl(0, 65%, 90%, 1);
+  --color-red-light-5: hsl(0, 100%, 94%, 1);
+  --color-red-light-6: hsl(0, 55%, 98%, 1);
   --color-red: hsl(0, 84%, 60%, 1);
   --color-red-dark-1: hsl(0, 72%, 50%, 1);
   --color-red-dark-2: hsl(0, 75%, 40%, 1);


### PR DESCRIPTION
- Set ActionButtons icon color to black for better visibility.
- Tweak gap sizes in CellEditor and Sidebar for improved layout.
- Add BannerSlim component for inline form error messaging.
- Update Form to show error summaries via BannerSlim.
- Introduce utilities for error handling and border radius management.
- Refactor components to use new design system features and styles.

Refs: #34