### PR TITLE
feat(frontend): add segmented control

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-export default { extends: ['@commitlint/config-conventional'] };
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [2, 'always', 200],
+  },
+};

--- a/frontend/src/components/Notebooks/Notebook/Notebook.tsx
+++ b/frontend/src/components/Notebooks/Notebook/Notebook.tsx
@@ -3,16 +3,21 @@ import { Cell } from "src/components/Notebooks/Notebook/Cell";
 import { ChartCell } from "src/components/Notebooks/Notebook/ChartCell";
 import { NotebookMenuBar } from "src/components/Notebooks/Notebook/NotebookMenuBar";
 import { useNotebookStore } from "src/components/Notebooks/store";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNotebook } from "src/api/notebook/queries";
 import { CellType } from "src/components/Notebooks/Notebook/Cell/dto";
 import { KEYBOARD_SHORTCUTS } from "src/utils/keyboard_shortcuts";
 import { useHandleExecuteCell } from "src/components/Notebooks/Notebook/Cell";
 import { useKeyboardShortcut } from "src/utils/keyboard_shortcuts/hooks";
-import { Heading } from "src/components/design-system";
+import { Heading, SegmentedControl } from "src/components/design-system";
 import { Text } from "src/components/design-system/Text/Text";
 import { Flex } from "src/components/design-system/Flex/Flex";
 import { Sticky } from "src/components/design-system/Sticky/Sticky";
+
+enum ViewType {
+  NOTEBOOK = "NOTEBOOK",
+  DASHBOARD = "DASHBOARD",
+}
 
 export function Notebook() {
   let params = useParams();
@@ -21,6 +26,7 @@ export function Notebook() {
   const query = useNotebook(params.id!);
   const handleExecuteCell = useHandleExecuteCell();
   const notebookRef = useRef<HTMLDivElement>(null);
+  const [viewType, setViewType] = useState<ViewType>(ViewType.NOTEBOOK);
 
   function handleExecute() {
     handleExecuteCell(activeCellId);
@@ -77,7 +83,28 @@ export function Notebook() {
       overflow="scrollY"
     >
       <Flex direction="column" gap="sm">
-        <Heading accessbilityLevel={1}>{query.data.name}</Heading>
+        <Flex direction="row" justifyContent="space-between">
+          <Heading accessbilityLevel={1}>{query.data.name}</Heading>
+          <SegmentedControl
+            options={[
+              {
+                label: "Notebook",
+                value: "notebook",
+                leadingIcon: "book",
+              },
+              {
+                label: "Dashboard",
+                value: "dashboard",
+                leadingIcon: "calendar",
+              },
+            ]}
+            value={viewType.toLowerCase()}
+            onValueChange={(v) =>
+              setViewType(ViewType[v.toUpperCase() as keyof typeof ViewType])
+            }
+            size="md"
+          />
+        </Flex>
         <Text as="p" color="subtle">
           {query.data.description}
         </Text>

--- a/frontend/src/components/design-system/Icon/Icon.tsx
+++ b/frontend/src/components/design-system/Icon/Icon.tsx
@@ -78,12 +78,7 @@ type IconProps = {
   size?: IconSize;
 };
 
-export function Icon({
-  type,
-  color,
-  strokeWidth = 2.25,
-  size = "md",
-}: IconProps) {
+export function Icon({ type, color, strokeWidth = 2, size = "md" }: IconProps) {
   const className = styles[color];
   const IconComponent = iconMap[type];
   const iconSize = sizeMap[size];

--- a/frontend/src/components/design-system/SegmentedControl/SegmentedControl.module.css
+++ b/frontend/src/components/design-system/SegmentedControl/SegmentedControl.module.css
@@ -1,0 +1,50 @@
+.root {
+  display: flex;
+  flex-direction: col;
+  background-color: var(--color-grey-200);
+  width: fit-content;
+  border-radius: var(--border-radius-lg);
+  border: var(--border-width-medium) solid var(--color-grey-300);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-family-primary);
+  cursor: pointer;
+}
+
+.segment {
+  border-radius: var(--border-radius-lg);
+  padding: var(--space-2xs) var(--space-sm);
+  display: flex;
+  flex-direction: row;
+  gap: var(--space-2xs);
+  align-items: center;
+  align-content: center;
+  border: var(--border-width-medium) solid var(--color-grey-200);
+  color: var(--color-grey-600);
+}
+
+.segment:hover {
+  background-color: var(--color-grey-300);
+  color: var(--color-grey-900);
+}
+
+.segmentSelected {
+  border: var(--border-width-medium) solid var(--color-grey-300);
+  background-color: var(--color-grey-100);
+  color: var(--color-grey-700);
+}
+
+.segmentSelected:hover {
+  background-color: var(--color-grey-100);
+}
+
+.iconContainer {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.segmentSelected .label {
+  font-weight: var(--font-weight-medium);
+}

--- a/frontend/src/components/design-system/SegmentedControl/SegmentedControl.tsx
+++ b/frontend/src/components/design-system/SegmentedControl/SegmentedControl.tsx
@@ -1,0 +1,57 @@
+import SegmentedControlStyles from "src/components/design-system/SegmentedControl/SegmentedControl.module.css";
+import { IconType } from "src/components/design-system/datatypes";
+import { Icon } from "../Icon";
+
+export type SegmentedControlOption = {
+  label: string;
+  value: string;
+  leadingIcon?: IconType;
+};
+
+export type SegmentedControlProps = {
+  options: SegmentedControlOption[];
+  value: string;
+  onValueChange: (value: string) => void;
+  disabled?: boolean;
+  size: "sm" | "md" | "lg";
+};
+
+export function SegmentedControl({
+  options,
+  value,
+  onValueChange,
+  disabled = false,
+}: SegmentedControlProps) {
+  return (
+    <div className={SegmentedControlStyles.root} role="tablist">
+      {options.map((option) => {
+        const isSelected = option.value === value;
+        const iconColor = isSelected ? "accent" : "grey";
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="tab"
+            aria-selected={isSelected}
+            disabled={disabled}
+            className={`${SegmentedControlStyles.segment} ${
+              isSelected ? SegmentedControlStyles.segmentSelected : ""
+            }`}
+            onClick={() => !disabled && onValueChange(option.value)}
+          >
+            {option.leadingIcon && (
+              <span className={SegmentedControlStyles.iconContainer}>
+                <Icon
+                  type={option.leadingIcon}
+                  color={iconColor}
+                  size="md"
+                ></Icon>
+              </span>
+            )}
+            <span className={SegmentedControlStyles.label}>{option.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/design-system/SegmentedControl/index.tsx
+++ b/frontend/src/components/design-system/SegmentedControl/index.tsx
@@ -1,0 +1,6 @@
+export { SegmentedControl } from "src/components/design-system/SegmentedControl/SegmentedControl";
+export type {
+  SegmentedControlOption,
+  SegmentedControlProps,
+} from "src/components/design-system/SegmentedControl/SegmentedControl";
+

--- a/frontend/src/components/design-system/index.tsx
+++ b/frontend/src/components/design-system/index.tsx
@@ -11,4 +11,12 @@ export type { SelectOption } from "src/components/design-system/Select";
 export { Flex } from "src/components/design-system/Flex/Flex";
 export { Text } from "src/components/design-system/Text";
 export { BannerSlim } from "src/components/design-system/BannerSlim";
-export { InfoIconTooltip, InfoIconTooltipStyles } from "src/components/design-system/InfoIconTooltip";
+export {
+  InfoIconTooltip,
+  InfoIconTooltipStyles,
+} from "src/components/design-system/InfoIconTooltip";
+export { SegmentedControl } from "src/components/design-system/SegmentedControl";
+export type {
+  SegmentedControlOption,
+  SegmentedControlProps,
+} from "src/components/design-system/SegmentedControl";


### PR DESCRIPTION
- Introduce a segmented control in the Notebook component to toggle between "Notebook" and "Dashboard" views.
- Update the Notebook component to manage the selected view type using state.
- Add segmented control component to design system components.

Refs: #42