### PR TITLE
feat: implement dashboard with drag and drop, and chart resizing

### DIFF
--- a/backend/migration/src/m20250315_000001_create_dashboard_table.rs
+++ b/backend/migration/src/m20250315_000001_create_dashboard_table.rs
@@ -15,8 +15,8 @@ impl MigrationTrait for Migration {
                     .col(pk_uuid(Dashboard::Id))
                     .col(uuid(Dashboard::CanvasId))
                     .col(string(Dashboard::Name))
-                    .col(string(Dashboard::Title))
                     .col(string(Dashboard::Description))
+                    .col(json_binary_null(Dashboard::Layout))
                     .col(string(Dashboard::Status))
                     .to_owned(),
             ))
@@ -36,7 +36,7 @@ enum Dashboard {
     Id,
     CanvasId,
     Name,
-    Title,
     Description,
+    Layout,
     Status,
 }

--- a/backend/src/canvas/service.rs
+++ b/backend/src/canvas/service.rs
@@ -125,8 +125,8 @@ pub async fn create_canvas(
         &txn,
         canvas_id,
         payload.name.clone(),
-        payload.name.clone(),
         payload.description.clone().unwrap_or_default(),
+        None,
     )
     .await
     {

--- a/backend/src/cell/constants.rs
+++ b/backend/src/cell/constants.rs
@@ -53,6 +53,35 @@ impl CellType {
         let s = value.to_string();
         serializer.serialize_str(&s)
     }
+
+    pub fn deserialize_option_from_str<'de, D>(deserializer: D) -> Result<Option<Self>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: Option<String> = Option::deserialize(deserializer)?;
+        match s {
+            Some(s) => Self::from_str(&s)
+                .map(Some)
+                .map_err(serde::de::Error::custom),
+            None => Ok(None),
+        }
+    }
+
+    pub fn serialize_option_to_str<S>(
+        value: &Option<Self>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match value {
+            Some(v) => {
+                let s = v.to_string();
+                serializer.serialize_some(&s)
+            }
+            None => serializer.serialize_none(),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/backend/src/cell/mod.rs
+++ b/backend/src/cell/mod.rs
@@ -2,6 +2,6 @@ mod controller;
 pub mod dto;
 mod repository;
 pub mod service;
-mod constants;
+pub mod constants;
 
 pub use controller::routes;

--- a/backend/src/cell/repository.rs
+++ b/backend/src/cell/repository.rs
@@ -1,12 +1,13 @@
-use sea_orm::{ActiveModelTrait, EntityTrait, DatabaseConnection, DbErr, DatabaseTransaction};
-use crate::entity::cell;
-use uuid::Uuid;
-use sea_orm::Set;
-use chrono::Utc;
+use crate::cell::constants::CellType;
 use crate::cell::dto;
-use sea_orm::QueryFilter;
+use crate::entity::cell;
+use chrono::Utc;
 use sea_orm::ColumnTrait;
-
+use sea_orm::Condition;
+use sea_orm::QueryFilter;
+use sea_orm::Set;
+use sea_orm::{ActiveModelTrait, DatabaseConnection, DatabaseTransaction, DbErr, EntityTrait};
+use uuid::Uuid;
 
 pub async fn save_cell(db: &DatabaseConnection, cell: cell::Model) -> Result<cell::Model, DbErr> {
     let cell_active_model: cell::ActiveModel = cell.into();
@@ -22,12 +23,34 @@ pub async fn get_cell(db: &DatabaseConnection, id: Uuid) -> Result<cell::Model, 
     }
 }
 
-pub async fn get_cells_by_notebook_id(db: &DatabaseConnection, notebook_id: Uuid) -> Result<Vec<cell::Model>, DbErr> {
-    let cells = cell::Entity::find().filter(cell::Column::NotebookId.eq(notebook_id)).all(db).await?;
+pub async fn get_cells_by_notebook_id(
+    db: &DatabaseConnection,
+    notebook_id: Uuid,
+) -> Result<Vec<cell::Model>, DbErr> {
+    let cells = cell::Entity::find()
+        .filter(cell::Column::NotebookId.eq(notebook_id))
+        .all(db)
+        .await?;
     Ok(cells)
 }
 
-pub async fn update_cell(db: &DatabaseConnection, cell_id: Uuid, payload: dto::CellDto) -> Result<cell::Model, DbErr> {
+pub async fn get_cells_by_notebook_id_and_cell_type(
+    db: &DatabaseConnection,
+    notebook_id: Uuid,
+    cell_type: CellType,
+) -> Result<Vec<cell::Model>, DbErr> {
+    let condition = Condition::all()
+        .add(cell::Column::NotebookId.eq(notebook_id))
+        .add(cell::Column::CellType.eq(cell_type.to_string()));
+    let cells = cell::Entity::find().filter(condition).all(db).await?;
+    Ok(cells)
+}
+
+pub async fn update_cell(
+    db: &DatabaseConnection,
+    cell_id: Uuid,
+    payload: dto::CellDto,
+) -> Result<cell::Model, DbErr> {
     let cell = get_cell(&db, cell_id).await;
     match cell {
         Ok(cell) => {

--- a/backend/src/cell/service.rs
+++ b/backend/src/cell/service.rs
@@ -69,12 +69,24 @@ async fn generate_cell_name(
     }
 }
 
-pub async fn get_cells_by_notebook_id(
+pub async fn get_cells_by_notebook_id_and_cell_type(
     app_state: &AppState,
     notebook_id: Uuid,
+    cell_type: Option<CellType>,
 ) -> Result<Vec<dto::CellDto>, SophoError> {
-    let cells =
-        repository::get_cells_by_notebook_id(&app_state.database_connection, notebook_id).await;
+    let cells = match cell_type {
+        Some(cell_type) => {
+            repository::get_cells_by_notebook_id_and_cell_type(
+                &app_state.database_connection,
+                notebook_id,
+                cell_type,
+            )
+            .await
+        }
+        None => {
+            repository::get_cells_by_notebook_id(&app_state.database_connection, notebook_id).await
+        }
+    };
     match cells {
         Ok(cells) => {
             let response_dtos: Vec<dto::CellDto> = cells
@@ -91,7 +103,7 @@ async fn get_number_of_cells_in_notebook(
     app_state: &AppState,
     notebook_id: Uuid,
 ) -> Result<i32, SophoError> {
-    let cells = get_cells_by_notebook_id(&app_state, notebook_id).await;
+    let cells = get_cells_by_notebook_id_and_cell_type(&app_state, notebook_id, None).await;
     match cells {
         Ok(cells) => Ok(cells.len() as i32),
         Err(e) => Err(e),
@@ -103,7 +115,7 @@ async fn get_number_of_cells_in_notebook_by_type(
     id: Uuid,
     cell_type: CellType,
 ) -> Result<i32, SophoError> {
-    let cells = get_cells_by_notebook_id(&app_state, id).await;
+    let cells = get_cells_by_notebook_id_and_cell_type(&app_state, id, None).await;
     match cells {
         Ok(cells) => {
             let count = cells
@@ -258,9 +270,7 @@ async fn execute_query_and_format_results(
     mut database_connection: PgConnection,
     query: &str,
 ) -> (http::StatusCode, axum::Json<JsonValue>) {
-    let result = sqlx::query(query)
-        .fetch_all(&mut database_connection)
-        .await;
+    let result = sqlx::query(query).fetch_all(&mut database_connection).await;
     let rows = match result {
         Ok(rows) => rows,
         Err(e) => {
@@ -300,6 +310,10 @@ async fn execute_query_and_format_results(
                 }
                 "UUID" => row.try_get::<Uuid, _>(i).map(|v| serde_json::json!(v)),
                 "TEXT" => {
+                    let value = row.try_get::<String, _>(i);
+                    value.map(serde_json::Value::String)
+                }
+                "JSONB" => {
                     let value = row.try_get::<String, _>(i);
                     value.map(serde_json::Value::String)
                 }
@@ -369,7 +383,9 @@ fn build_aggregated_query(
     )
 }
 
-fn get_sql_query_from_cell(cell: &entity::cell::Model) -> Result<String, (http::StatusCode, axum::Json<JsonValue>)> {
+fn get_sql_query_from_cell(
+    cell: &entity::cell::Model,
+) -> Result<String, (http::StatusCode, axum::Json<JsonValue>)> {
     let cell_content = match &cell.content {
         Some(cell_content) => cell_content,
         None => {
@@ -479,7 +495,9 @@ async fn execute_chart_cell(
         None => {
             return (
                 StatusCode::PRECONDITION_FAILED,
-                axum::Json(serde_json::json!({ "error": "ChartCell has no aggregate function specified" })),
+                axum::Json(
+                    serde_json::json!({ "error": "ChartCell has no aggregate function specified" }),
+                ),
             );
         }
     };
@@ -496,7 +514,9 @@ async fn execute_chart_cell(
         None => {
             return (
                 StatusCode::PRECONDITION_FAILED,
-                axum::Json(serde_json::json!({ "error": "Source cell has no connection assigned" })),
+                axum::Json(
+                    serde_json::json!({ "error": "Source cell has no connection assigned" }),
+                ),
             );
         }
     };

--- a/backend/src/dashboard/controller.rs
+++ b/backend/src/dashboard/controller.rs
@@ -1,27 +1,35 @@
+use crate::common::AppState;
+use crate::dashboard::dto;
+use crate::dashboard::service;
+use axum::extract::State;
 use axum::{
     response::IntoResponse,
-    routing::{get, post},
+    routing::{get, post, put},
     Router,
 };
-use crate::dashboard::dto;
 use uuid::Uuid;
-use axum::extract::State;
-use crate::common::AppState;
-use crate::dashboard::service;
-
 
 pub fn routes(app_state: AppState) -> Router {
     Router::new()
         .route("/{id}", get(get_dashboard))
+        .route("/canvas/{canvas_id}", get(get_dashboard_by_canvas_id))
         .route("/", post(create_dashboard))
+        .route("/{id}", put(update_dashboard))
         .with_state(app_state)
 }
 
 async fn get_dashboard(
     State(app_state): State<AppState>,
-    axum::extract::Path(id): axum::extract::Path<Uuid>,
+    axum::extract::Path(dashboard_id): axum::extract::Path<Uuid>,
 ) -> impl IntoResponse {
-    service::get_dashboard(app_state, id).await
+    service::get_dashboard(app_state, dashboard_id).await
+}
+
+async fn get_dashboard_by_canvas_id(
+    State(app_state): State<AppState>,
+    axum::extract::Path(canvas_id): axum::extract::Path<Uuid>,
+) -> impl IntoResponse {
+    service::get_dashboard_by_canvas_id(app_state, canvas_id).await
 }
 
 async fn create_dashboard(
@@ -29,4 +37,12 @@ async fn create_dashboard(
     axum::extract::Json(payload): axum::extract::Json<dto::CreateDashboardDto>,
 ) -> impl IntoResponse {
     service::create_dashboard(app_state, payload).await
+}
+
+async fn update_dashboard(
+    State(app_state): State<AppState>,
+    axum::extract::Path(dashboard_id): axum::extract::Path<Uuid>,
+    axum::extract::Json(payload): axum::extract::Json<dto::DashboardDto>,
+) -> impl IntoResponse {
+    service::update_dashboard(app_state, dashboard_id, payload).await
 }

--- a/backend/src/dashboard/dto.rs
+++ b/backend/src/dashboard/dto.rs
@@ -1,33 +1,61 @@
-use serde::{Serialize, Deserialize};
-use uuid::Uuid;
-use crate::entity;
 use crate::dashboard::constants::DashboardStatus;
+use crate::entity;
+use sea_orm::entity::prelude::Json;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateDashboardDto {
     pub name: String,
     pub description: String,
-    pub title: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Layout {
+    cell_id: Uuid,
+    notebook_id: Uuid,
+    x_position: u16,
+    y_position: u16,
+    x_size: u16,
+    y_size: u16,
+}
+
+impl Layout {
+    pub fn to_json(layout: Option<Vec<Layout>>) -> Option<Json> {
+        layout.map(|layouts| {
+            let value = serde_json::to_value(layouts).unwrap_or(serde_json::Value::Null);
+            Json::from(value)
+        })
+    }
+
+    pub fn from_json(json: Option<Json>) -> Option<Vec<Layout>> {
+        json.and_then(|j| {
+            let value: serde_json::Value = j.into();
+            serde_json::from_value(value).ok()
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DashboardDto {
     pub id: Uuid,
-    pub name: String,
-    pub description: String,
-    pub title: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub layout: Option<Vec<Layout>>,
+    #[serde(deserialize_with = "DashboardStatus::deserialize_from_str")]
     #[serde(serialize_with = "DashboardStatus::serialize_to_str")]
     pub status: DashboardStatus,
 }
 
 impl From<entity::dashboard::Model> for DashboardDto {
     fn from(model: entity::dashboard::Model) -> Self {
+        let layout = Layout::from_json(model.layout);
         Self {
             id: model.id,
-            name: model.name,
-            description: model.description,
-            title: model.title,
+            name: Some(model.name),
+            description: Some(model.description),
             status: DashboardStatus::from_str(&model.status).unwrap(),
+            layout,
         }
     }
 }

--- a/backend/src/dashboard/repository.rs
+++ b/backend/src/dashboard/repository.rs
@@ -1,7 +1,9 @@
+use crate::dashboard::dto;
 use crate::entity::dashboard;
+use chrono::Utc;
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, DatabaseConnection, DatabaseTransaction, DbErr, EntityTrait,
-    QueryFilter,
+    QueryFilter, Set,
 };
 use uuid::Uuid;
 
@@ -65,4 +67,30 @@ pub async fn delete_dashboard_transaction(
 ) -> Result<(), DbErr> {
     dashboard::Entity::delete_by_id(id).exec(txn).await?;
     Ok(())
+}
+
+pub async fn update_dashboard(
+    db: &DatabaseConnection,
+    dashboard_id: Uuid,
+    payload: dto::DashboardDto,
+) -> Result<dashboard::Model, DbErr> {
+    let dashboard = get_dashboard(&db, dashboard_id).await;
+    match dashboard {
+        Ok(dashboard) => {
+            let mut dashboard_entity: dashboard::ActiveModel = dashboard.into();
+            if let Some(name) = payload.name {
+                dashboard_entity.name = Set(name);
+            }
+            if let Some(description) = payload.description {
+                dashboard_entity.description = Set(description);
+            }
+            dashboard_entity.status = Set(payload.status.to_string());
+            dashboard_entity.layout = Set(dto::Layout::to_json(payload.layout));
+            dashboard_entity.updated_at = Set(Utc::now().into());
+
+            let dashboard_entity = dashboard_entity.update(db).await;
+            return dashboard_entity;
+        }
+        Err(e) => Err(e),
+    }
 }

--- a/backend/src/dashboard/service.rs
+++ b/backend/src/dashboard/service.rs
@@ -1,6 +1,7 @@
 use crate::common::AppState;
 use crate::dashboard::constants::DashboardStatus;
 use crate::dashboard::dto;
+use crate::dashboard::dto::Layout;
 use crate::dashboard::repository;
 use crate::entity;
 use axum::http::StatusCode;
@@ -29,6 +30,30 @@ pub async fn get_dashboard(app_state: AppState, id: Uuid) -> impl IntoResponse {
     }
 }
 
+pub async fn get_dashboard_by_canvas_id(
+    app_state: AppState,
+    canvas_id: Uuid,
+) -> impl IntoResponse {
+    let dashboard =
+        repository::get_dashboard_by_canvas_id(&app_state.database_connection, canvas_id).await;
+    match dashboard {
+        Ok(dashboard) => {
+            let response_dto = dto::DashboardDto::from(dashboard);
+            (StatusCode::OK, axum::Json(serde_json::json!(response_dto)))
+        }
+        Err(e) => match e {
+            sea_orm::DbErr::RecordNotFound(_) => (
+                StatusCode::NOT_FOUND,
+                axum::Json(serde_json::json!({ "error": "Dashboard not found" })),
+            ),
+            _ => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(serde_json::json!({ "error": e.to_string() })),
+            ),
+        },
+    }
+}
+
 pub async fn create_dashboard(
     app_state: AppState,
     payload: dto::CreateDashboardDto,
@@ -39,9 +64,9 @@ pub async fn create_dashboard(
         name: payload.name,
         description: payload.description,
         status: DashboardStatus::Active.to_string(),
-        title: payload.title,
         created_at: Utc::now().into(),
         updated_at: Utc::now().into(),
+        layout: None,
     };
 
     match repository::save_dashboard_connection(&app_state.database_connection, dashboard_entity)
@@ -71,16 +96,16 @@ pub async fn create_dashboard_transaction(
     txn: &DatabaseTransaction,
     canvas_id: Uuid,
     name: String,
-    title: String,
     description: String,
+    layout: Option<Vec<Layout>>,
 ) -> Result<entity::dashboard::Model, sea_orm::DbErr> {
     let dashboard_entity = entity::dashboard::Model {
         id: Uuid::new_v4(),
         canvas_id,
         name,
         description,
+        layout: Layout::to_json(layout),
         status: DashboardStatus::Active.to_string(),
-        title,
         created_at: Utc::now().into(),
         updated_at: Utc::now().into(),
     };
@@ -99,4 +124,29 @@ pub async fn delete_dashboard_transaction(
     id: Uuid,
 ) -> Result<(), sea_orm::DbErr> {
     repository::delete_dashboard_transaction(txn, id).await
+}
+
+pub async fn update_dashboard(
+    app_state: AppState,
+    dashboard_id: Uuid,
+    payload: dto::DashboardDto,
+) -> impl IntoResponse {
+    let dashboard =
+        repository::update_dashboard(&app_state.database_connection, dashboard_id, payload).await;
+    match dashboard {
+        Ok(dashboard) => {
+            let response_dto = dto::DashboardDto::from(dashboard);
+            (StatusCode::OK, axum::Json(serde_json::json!(response_dto)))
+        }
+        Err(e) => match e {
+            sea_orm::DbErr::RecordNotFound(_) => (
+                StatusCode::NOT_FOUND,
+                axum::Json(serde_json::json!({ "error": "Dashboard not found" })),
+            ),
+            _ => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(serde_json::json!({ "error": e.to_string() })),
+            ),
+        },
+    }
 }

--- a/backend/src/entity/dashboard.rs
+++ b/backend/src/entity/dashboard.rs
@@ -9,8 +9,9 @@ pub struct Model {
     pub id: Uuid,
     pub canvas_id: Uuid,
     pub name: String,
-    pub title: String,
     pub description: String,
+    #[sea_orm(column_type = "JsonBinary", nullable)]
+    pub layout: Option<Json>,
     pub status: String,
     pub created_at: DateTimeWithTimeZone,
     pub updated_at: DateTimeWithTimeZone,

--- a/backend/src/notebook/constants.rs
+++ b/backend/src/notebook/constants.rs
@@ -1,5 +1,5 @@
-use serde::{Serialize, Deserialize};
-
+use crate::cell::constants::CellType;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum NotebookStatus {
@@ -40,5 +40,20 @@ impl NotebookStatus {
     {
         let s = value.to_string();
         serializer.serialize_str(&s)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct QueryFilters {
+    #[serde(
+        deserialize_with = "CellType::deserialize_option_from_str",
+        serialize_with = "CellType::serialize_option_to_str"
+    )]
+    cell_type: Option<CellType>,
+}
+
+impl QueryFilters {
+    pub fn cell_type(&self) -> Option<CellType> {
+        return self.cell_type.clone();
     }
 }

--- a/backend/src/notebook/controller.rs
+++ b/backend/src/notebook/controller.rs
@@ -1,5 +1,6 @@
 use crate::common::AppState;
 use crate::common::Pagination;
+use crate::notebook::constants::QueryFilters;
 use crate::notebook::dto;
 use crate::notebook::service;
 use axum::extract::Path;
@@ -13,6 +14,7 @@ pub fn routes(app_state: AppState) -> Router {
     Router::new()
         .route("/canvas/{canvas_id}", get(get_notebooks_by_canvas_id))
         .route("/{id}", get(get_notebook))
+        .route("/{id}/cells", get(get_cells_by_notebook_id))
         .route("/", get(get_all_notebooks))
         .route("/", post(create_notebook))
         .with_state(app_state)
@@ -30,6 +32,14 @@ async fn get_all_notebooks(
     pagination: Query<Pagination>,
 ) -> impl IntoResponse {
     service::get_all_notebooks(app_state, pagination).await
+}
+
+async fn get_cells_by_notebook_id(
+    State(app_state): State<AppState>,
+    Path(id): Path<Uuid>,
+    filters: Query<QueryFilters>,
+) -> impl IntoResponse {
+    service::get_cells_by_notebook_id(app_state, id, filters).await
 }
 
 async fn create_notebook(

--- a/backend/src/notebook/dto.rs
+++ b/backend/src/notebook/dto.rs
@@ -1,15 +1,14 @@
-use uuid::Uuid;
-use chrono::{DateTime, FixedOffset};
-use serde::{Serialize, Deserialize};
-use crate::entity;
 use crate::cell::dto::CellDto;
+use crate::entity;
+use chrono::{DateTime, FixedOffset};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateNotebookDto {
     pub name: String,
     pub description: Option<String>,
 }
-
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NotebookDto {

--- a/backend/src/notebook/service.rs
+++ b/backend/src/notebook/service.rs
@@ -1,7 +1,7 @@
 use crate::cell::service as cell_service;
 use crate::common::{AppState, PaginatedResponse, Pagination};
 use crate::entity;
-use crate::notebook::constants::NotebookStatus;
+use crate::notebook::constants::{NotebookStatus, QueryFilters};
 use crate::notebook::dto;
 use crate::notebook::repository;
 use axum::extract::Query;
@@ -22,7 +22,8 @@ pub async fn get_notebook(app_state: AppState, id: Uuid) -> impl IntoResponse {
     match notebook {
         Ok(notebook) => {
             let mut response_dto = dto::NotebookDto::from(notebook);
-            let cells = cell_service::get_cells_by_notebook_id(&app_state, id).await;
+            let cells =
+                cell_service::get_cells_by_notebook_id_and_cell_type(&app_state, id, None).await;
             match cells {
                 Ok(cells) => {
                     response_dto.cells = cells;
@@ -80,6 +81,43 @@ pub async fn get_all_notebooks(
             StatusCode::INTERNAL_SERVER_ERROR,
             axum::Json(serde_json::json!({ "error": e.to_string() })),
         ),
+    }
+}
+
+pub async fn get_cells_by_notebook_id(
+    app_state: AppState,
+    notebook_id: Uuid,
+    filters: Query<QueryFilters>,
+) -> impl IntoResponse {
+    let notebook = repository::get_notebook(&app_state.database_connection, notebook_id).await;
+    let notebook = match notebook {
+        Ok(notebook) => notebook,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(serde_json::json!({ "error": e.to_string() })),
+            )
+        }
+    };
+
+    let cells = cell_service::get_cells_by_notebook_id_and_cell_type(
+        &app_state,
+        notebook_id,
+        filters.cell_type(),
+    )
+    .await;
+    match cells {
+        Ok(cells) => {
+            let mut response_dto = dto::NotebookDto::from(notebook);
+            response_dto.cells = cells;
+            return (StatusCode::OK, axum::Json(serde_json::json!(response_dto)));
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(serde_json::json!({ "error": e.to_string() })),
+            )
+        }
     }
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,6 +36,7 @@
         "material-symbols": "^0.31.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-grid-layout": "^1.5.3",
         "react-router": "^7.5.1",
         "vite-tsconfig-paths": "^5.1.4",
         "zustand": "^5.0.4"
@@ -44,6 +45,7 @@
         "@eslint/js": "^9.21.0",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
+        "@types/react-grid-layout": "^1.3.6",
         "@vitejs/plugin-react": "^4.3.4",
         "eslint": "^9.21.0",
         "eslint-plugin-react-hooks": "^5.1.0",
@@ -4062,6 +4064,16 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/react-grid-layout": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@types/react-grid-layout/-/react-grid-layout-1.3.6.tgz",
+      "integrity": "sha512-Cw7+sb3yyjtmxwwJiXtEXcu5h4cgs+sCGkHwHXsFmPyV30bf14LeD/fa2LwQovuD2HWxCcjIdNhDlcYGj95qGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/send": {
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
@@ -4515,6 +4527,15 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/codemirror": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
@@ -4909,6 +4930,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -5191,7 +5218,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5307,6 +5333,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5407,6 +5445,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -5566,6 +5613,17 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5617,6 +5675,44 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.5.3.tgz",
+      "integrity": "sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.0.5",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5675,6 +5771,19 @@
         }
       }
     },
+    "node_modules/react-resizable": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.5.tgz",
+      "integrity": "sha512-vKpeHhI5OZvYn82kXOs1bC8aOXktGU5AmKAgaZS4F5JPburCtbmDPqE7Pzp+1kN4+Wb81LlF33VpGwWwtXem+w==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3"
+      }
+    },
     "node_modules/react-router": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.0.tgz",
@@ -5718,6 +5827,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "material-symbols": "^0.31.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-grid-layout": "^1.5.3",
     "react-router": "^7.5.1",
     "vite-tsconfig-paths": "^5.1.4",
     "zustand": "^5.0.4"
@@ -47,6 +48,7 @@
     "@eslint/js": "^9.21.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
+    "@types/react-grid-layout": "^1.3.6",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.21.0",
     "eslint-plugin-react-hooks": "^5.1.0",

--- a/frontend/src/api/dashboard/index.tsx
+++ b/frontend/src/api/dashboard/index.tsx
@@ -1,0 +1,6 @@
+export {
+  useDashboard,
+  useDashboardByCanvasId,
+  useUpdateDashboard,
+} from "src/api/dashboard/queries";
+

--- a/frontend/src/api/dashboard/queries.tsx
+++ b/frontend/src/api/dashboard/queries.tsx
@@ -1,0 +1,85 @@
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { ApiService } from "src/utils/api_client";
+import { API_ENDPOINTS } from "src/constants/api_endpoints";
+import { DashboardDto } from "src/components/Dashboard/dto";
+
+export const dashboardKeys = {
+  all: ["dashboards"] as const,
+  details: () => [...dashboardKeys.all, "detail"] as const,
+  detail: (id: string) => [...dashboardKeys.details(), id] as const,
+  byCanvas: (canvasId: string) =>
+    [...dashboardKeys.all, "byCanvas", canvasId] as const,
+};
+
+const dashboardApi = {
+  getDashboard: async (dashboardId: string): Promise<DashboardDto> => {
+    const response = await ApiService.get({
+      url: `${import.meta.env.VITE_API_HOSTNAME}${API_ENDPOINTS.DASHBOARD.GET_BY_ID?.replace(":id", dashboardId) || `/dashboard/${dashboardId}`}`,
+      onlyBody: true,
+    });
+    return response as DashboardDto;
+  },
+
+  getDashboardByCanvasId: async (canvasId: string): Promise<DashboardDto> => {
+    const response = await ApiService.get({
+      url: `${import.meta.env.VITE_API_HOSTNAME}${API_ENDPOINTS.DASHBOARD.GET_BY_CANVAS_ID?.replace(":canvas_id", canvasId) || `/dashboard/canvas/${canvasId}`}`,
+      onlyBody: true,
+    });
+    return response as DashboardDto;
+  },
+
+  updateDashboard: async ({
+    dashboardId,
+    payload,
+  }: {
+    dashboardId: string;
+    payload: Partial<DashboardDto>;
+  }): Promise<DashboardDto> => {
+    const response = await ApiService.put({
+      url: `${import.meta.env.VITE_API_HOSTNAME}${API_ENDPOINTS.DASHBOARD.UPDATE.replace(":id", dashboardId)}`,
+      data: payload,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    return response as DashboardDto;
+  },
+};
+
+export const useDashboard = (dashboardId: string) => {
+  return useQuery({
+    queryKey: dashboardKeys.detail(dashboardId),
+    queryFn: () => dashboardApi.getDashboard(dashboardId),
+    enabled: !!dashboardId,
+  });
+};
+
+export const useDashboardByCanvasId = (canvasId: string) => {
+  return useQuery({
+    queryKey: dashboardKeys.byCanvas(canvasId),
+    queryFn: () => dashboardApi.getDashboardByCanvasId(canvasId),
+    enabled: !!canvasId,
+  });
+};
+
+export const useUpdateDashboard = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: dashboardApi.updateDashboard,
+    onSuccess: (data, { dashboardId }) => {
+      queryClient.setQueryData(dashboardKeys.detail(dashboardId), data);
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.all,
+      });
+    },
+    onError: (error) => {
+      console.error("Failed to update dashboard:", error);
+    },
+  });
+};
+

--- a/frontend/src/api/notebook/queries.tsx
+++ b/frontend/src/api/notebook/queries.tsx
@@ -20,6 +20,9 @@ export const notebookKeys = {
   detail: (id: string) => [...notebookKeys.details(), id] as const,
   byCanvas: (canvasId: string) =>
     [...notebookKeys.all, "byCanvas", canvasId] as const,
+  cells: () => [...notebookKeys.all, "cells"] as const,
+  cellsByNotebook: (notebookId: string, cellType?: string) =>
+    [...notebookKeys.cells(), notebookId, { cellType }] as const,
 };
 
 // API functions
@@ -111,6 +114,23 @@ const notebookApi = {
     });
     return response as NotebookDto[];
   },
+
+  getCellsByNotebookId: async (
+    notebookId: string,
+    cellType?: string
+  ): Promise<NotebookDto> => {
+    const url = new URL(
+      `${import.meta.env.VITE_API_HOSTNAME}${API_ENDPOINTS.NOTEBOOK.GET_CELLS_BY_NOTEBOOK_ID?.replace(":id", notebookId) || `/notebooks/${notebookId}/cells`}`
+    );
+    if (cellType) {
+      url.searchParams.set("cell_type", cellType);
+    }
+    const response = await ApiService.get({
+      url: url.toString(),
+      onlyBody: true,
+    });
+    return response as NotebookDto;
+  },
 };
 
 // Query hooks
@@ -135,6 +155,14 @@ export const useNotebooksByCanvasId = (canvasId: string) => {
     queryKey: notebookKeys.byCanvas(canvasId),
     queryFn: () => notebookApi.getNotebooksByCanvasId(canvasId),
     enabled: !!canvasId,
+  });
+};
+
+export const useCellsByNotebookId = (notebookId: string, cellType?: string) => {
+  return useQuery({
+    queryKey: notebookKeys.cellsByNotebook(notebookId, cellType),
+    queryFn: () => notebookApi.getCellsByNotebookId(notebookId, cellType),
+    enabled: !!notebookId,
   });
 };
 

--- a/frontend/src/components/Canvases/Canvas/Canvas.tsx
+++ b/frontend/src/components/Canvases/Canvas/Canvas.tsx
@@ -10,6 +10,7 @@ import {
 } from "src/components/design-system";
 import { Notebook } from "src/components/Notebook";
 import { useCanvasStore } from "src/components/Canvases/store";
+import { Dashboard } from "src/components/Dashboard";
 
 enum ViewType {
   NOTEBOOK = "NOTEBOOK",
@@ -39,7 +40,7 @@ export function Canvas() {
 
   const renderView = () => {
     if (viewType == ViewType.DASHBOARD) {
-      return null;
+      return <Dashboard />;
     }
     return <Notebook />;
   };

--- a/frontend/src/components/Dashboard/Dashboard.module.css
+++ b/frontend/src/components/Dashboard/Dashboard.module.css
@@ -1,0 +1,110 @@
+.gridItem {
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  position: relative;
+}
+
+.gridItem * {
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+
+.layout {
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+
+.layoutEditing {
+  border: var(--border-primary-medium);
+  border-radius: var(--border-radius-lg);
+}
+
+.dragHandle {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--border-radius-md);
+  cursor: grab;
+  transition:
+    opacity 0.15s ease,
+    background-color 0.15s ease;
+  z-index: var(--z-index-2);
+}
+
+.dragHandle:hover {
+  background-color: var(--color-grey-200);
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+  background-color: var(--color-primary-100);
+}
+
+.gridItem :global(.react-resizable-handle),
+.gridItem :global(.react-resizable-handle-se) {
+  position: absolute !important;
+  bottom: 0 !important;
+  right: 0 !important;
+  width: 32px !important;
+  height: 32px !important;
+  min-width: 32px !important;
+  min-height: 32px !important;
+  max-width: 32px !important;
+  max-height: 32px !important;
+  background: transparent !important;
+  cursor: nwse-resize !important;
+  transition: opacity 0.2s ease;
+  z-index: var(--z-index-2) !important;
+  border: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  box-sizing: border-box !important;
+}
+
+.gridItem :global(.react-resizable-handle)::after,
+.gridItem :global(.react-resizable-handle-se)::after {
+  content: "" !important;
+  position: absolute !important;
+  bottom: 0 !important;
+  right: 0 !important;
+  width: 15px !important;
+  height: 15px !important;
+  min-width: 15px !important;
+  min-height: 15px !important;
+  border-radius: 0 0 var(--border-radius-lg) 0 !important;
+  transition: background-color 0.2s ease;
+  pointer-events: none;
+  box-sizing: border-box !important;
+}
+
+.gridItem :global(.react-grid-item.react-draggable-dragging) {
+  background-color: var(--color-primary-200) !important;
+  border-radius: var(--border-radius-md) !important;
+}
+
+.gridItem :global(.react-grid-item.react-draggable-dragging)::before {
+  background-color: var(--color-primary-200) !important;
+  border-radius: var(--border-radius-md) !important;
+}
+
+:global(.react-grid-item.react-draggable-dragging) {
+  background-color: var(--color-primary-200) !important;
+  border-radius: var(--border-radius-md) !important;
+}
+
+:global(.react-grid-placeholder) {
+  background-color: var(--color-primary-200) !important;
+  border-radius: var(--border-radius-md) !important;
+  opacity: 0.3 !important;
+}

--- a/frontend/src/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/components/Dashboard/Dashboard.tsx
@@ -1,0 +1,121 @@
+import { useState, useEffect } from "react";
+import { useParams } from "react-router";
+import RGL, { WidthProvider, Layout } from "react-grid-layout";
+import { getInstanceByDom } from "echarts";
+import { useCellsByNotebookId } from "src/api/notebook/queries";
+import {
+  useDashboardByCanvasId,
+  useUpdateDashboard,
+} from "src/api/dashboard/queries";
+import { useCanvasStore } from "src/components/Canvases/store";
+import { CellType } from "src/components/Notebook/Cell";
+import { DashboardChart } from "src/components/Dashboard/DashboardChart";
+import {
+  convertRGLayoutToDto,
+  convertDtoToRGLayout,
+} from "src/components/Dashboard/dto";
+import { Button, Flex, Icon } from "src/components/design-system";
+import styles from "src/components/Dashboard/Dashboard.module.css";
+import "react-grid-layout/css/styles.css";
+
+const ReactGridLayout = WidthProvider(RGL);
+
+export function Dashboard() {
+  const params = useParams();
+  const canvasId = params.id || "";
+  const { activeNotebookId } = useCanvasStore();
+  const cellsByNotebookIdQuery = useCellsByNotebookId(
+    activeNotebookId,
+    CellType.CHART
+  );
+  const dashboardQuery = useDashboardByCanvasId(canvasId);
+  const updateDashboardMutation = useUpdateDashboard();
+  const cells = cellsByNotebookIdQuery.data?.cells ?? [];
+  const [layout, setLayout] = useState<Layout[]>([]);
+
+  useEffect(() => {
+    if (dashboardQuery.data?.layout) {
+      setLayout(convertDtoToRGLayout(dashboardQuery.data.layout));
+    }
+  }, [dashboardQuery.data]);
+
+  const handleLayoutChange = (newLayout: Layout[]) => {
+    setLayout(newLayout);
+  };
+
+  const handleDrag = () => {
+    const gridItems = document.querySelectorAll(".react-grid-item");
+    gridItems.forEach((item) => {
+      const divs = item.querySelectorAll("div");
+      divs.forEach((div) => {
+        const chart = getInstanceByDom(div as HTMLElement);
+        if (chart) {
+          chart.resize();
+        }
+      });
+    });
+  };
+
+  const handleDragStart = () => {
+    document.body.style.userSelect = "none";
+    document.body.style.webkitUserSelect = "none";
+  };
+
+  const handleDragStop = () => {
+    document.body.style.userSelect = "";
+    document.body.style.webkitUserSelect = "";
+    handleDrag();
+  };
+
+  if (cellsByNotebookIdQuery.isLoading || layout.length === 0) {
+    return null;
+  }
+
+  return (
+    <Flex direction="column" gap="md">
+      <Button
+        label="Save"
+        shape="rectangle"
+        size="sm"
+        backgroundColor="accent"
+        onClick={() => {
+          if (!dashboardQuery.data || !activeNotebookId) {
+            return;
+          }
+          const layoutDto = convertRGLayoutToDto(layout, activeNotebookId);
+          updateDashboardMutation.mutate({
+            dashboardId: dashboardQuery.data.id,
+            payload: {
+              ...dashboardQuery.data,
+              layout: layoutDto,
+            },
+          });
+        }}
+      />
+      <ReactGridLayout
+        className={`${styles.layout} ${styles.layoutEditing}`}
+        layout={layout}
+        cols={12}
+        rowHeight={100}
+        margin={[10, 10]}
+        onLayoutChange={handleLayoutChange}
+        onDragStart={handleDragStart}
+        onDrag={handleDrag}
+        onDragStop={handleDragStop}
+        onResize={handleDrag}
+        onResizeStop={handleDrag}
+        useCSSTransforms={true}
+        draggableHandle={`.${styles.dragHandle}`}
+      >
+        {cells.map((cell) => (
+          <div key={cell.id} className={styles.gridItem}>
+            <div className={styles.dragHandle}>
+              <Icon type="grip_vertical" color="grey" size="sm" />
+            </div>
+            <DashboardChart cellId={cell.id} />
+          </div>
+        ))}
+      </ReactGridLayout>
+    </Flex>
+  );
+}

--- a/frontend/src/components/Dashboard/DashboardChart.tsx
+++ b/frontend/src/components/Dashboard/DashboardChart.tsx
@@ -1,0 +1,65 @@
+import { useCell, useExecuteCell } from "src/api/cell";
+import { BarChart } from "../Chart";
+import { getChartContent } from "../Notebook/Cell";
+import { useEffect, useState } from "react";
+import { ExecuteCellResponseDto } from "../Notebook/Cell/dto";
+import { Flex, Heading } from "src/components/design-system";
+
+type DashboardChartProps = {
+  cellId: string;
+};
+
+export function DashboardChart({ cellId }: DashboardChartProps) {
+  const cellQuery = useCell(cellId);
+  const executeCellMutation = useExecuteCell();
+  const chartContent = cellQuery.data ? getChartContent(cellQuery.data) : null;
+  const [output, setOutput] = useState<ExecuteCellResponseDto | null>(null);
+
+  useEffect(() => {
+    executeCellMutation.mutate(cellId, {
+      onSuccess: (data) => {
+        setOutput(data);
+      },
+      onError: () => {},
+    });
+  }, []);
+
+  const isLoading =
+    cellQuery.isLoading ||
+    cellQuery.data == null ||
+    chartContent == null ||
+    output == null;
+
+  return (
+    <Flex
+      height="100%"
+      borderRadius="lg"
+      border="default"
+      shadow="2xs"
+      color="white"
+      direction="column"
+      paddingX="md"
+      paddingY="md"
+      gap="sm"
+      overflow="hidden"
+    >
+      <Flex>
+        <Heading accessbilityLevel={3} size="sm">
+          {cellQuery.data?.name}
+        </Heading>
+      </Flex>
+      {!isLoading && (
+        <BarChart
+          xAxis={chartContent.x_axis}
+          yAxis={chartContent.y_axis}
+          data={output.data as Object[]}
+          orientation={chartContent.orientation}
+          dimensions={output.columns?.map((column) => column.column_name) ?? []}
+          sortOrder={chartContent.y_axis_sort_order}
+          axisTickShow={chartContent.axis_tick_show}
+          axisMinorTickShow={chartContent.axis_minor_tick_show}
+        />
+      )}
+    </Flex>
+  );
+}

--- a/frontend/src/components/Dashboard/dto.tsx
+++ b/frontend/src/components/Dashboard/dto.tsx
@@ -1,0 +1,45 @@
+import { Layout } from "react-grid-layout";
+
+export type LayoutDto = {
+  cell_id: string;
+  notebook_id: string;
+  x_position: number;
+  y_position: number;
+  x_size: number;
+  y_size: number;
+};
+
+export type DashboardDto = {
+  id: string;
+  name?: string;
+  description?: string;
+  layout?: LayoutDto[];
+  status: "ACTIVE" | "INACTIVE";
+};
+
+export function convertRGLayoutToDto(
+  layout: Layout[],
+  notebookId: string
+): LayoutDto[] {
+  return layout.map((item) => ({
+    cell_id: item.i,
+    notebook_id: notebookId,
+    x_position: item.x,
+    y_position: item.y,
+    x_size: item.w,
+    y_size: item.h,
+  }));
+}
+
+export function convertDtoToRGLayout(layoutDto: LayoutDto[]): Layout[] {
+  return layoutDto.map((item) => ({
+    i: item.cell_id,
+    x: item.x_position,
+    y: item.y_position,
+    w: item.x_size,
+    h: item.y_size,
+    minW: 4,
+    minH: 3,
+  }));
+}
+

--- a/frontend/src/components/Dashboard/index.tsx
+++ b/frontend/src/components/Dashboard/index.tsx
@@ -1,0 +1,1 @@
+export { Dashboard } from "src/components/Dashboard/Dashboard";

--- a/frontend/src/components/design-system/Box/Box.module.css
+++ b/frontend/src/components/design-system/Box/Box.module.css
@@ -1,6 +1,10 @@
 .default {
 }
 
+.white {
+  background-color: var(--color-grey-100);
+}
+
 .error {
   background-color: var(--color-red-light-5);
 }

--- a/frontend/src/components/design-system/Box/index.tsx
+++ b/frontend/src/components/design-system/Box/index.tsx
@@ -1,0 +1,1 @@
+export { Box } from "src/components/design-system/Box/Box";

--- a/frontend/src/components/design-system/Button/Button.module.css
+++ b/frontend/src/components/design-system/Button/Button.module.css
@@ -4,6 +4,11 @@
   display: flex;
   border-radius: var(--border-radius-lg);
   transition: transform 0.15s ease-in-out;
+  width: fit-content;
+}
+
+.fullWidth {
+  width: 100%;
 }
 
 .button:active {

--- a/frontend/src/components/design-system/Button/Button.tsx
+++ b/frontend/src/components/design-system/Button/Button.tsx
@@ -49,13 +49,14 @@ export function Button({
   const backgroundColorClassName = styles[backgroundColor];
   const sizeClassName =
     styles[`size${size.charAt(0).toUpperCase() + size.slice(1)}`];
+  const fullWidthClassName = fullWidth ? styles.fullWidth : "";
   const textColor = backgroundColor === "white" ? "default" : "white";
   const iconColor = backgroundColor === "white" ? "black" : "white";
   return (
     <button
       type={type}
       disabled={disabled}
-      className={`${styles.button} ${sizeClassName} ${backgroundColorClassName}`}
+      className={`${styles.button} ${sizeClassName} ${backgroundColorClassName} ${fullWidthClassName}`}
       onClick={(e) => onClick({ event: e })}
     >
       {leadingIconName && (

--- a/frontend/src/components/design-system/Flex/index.tsx
+++ b/frontend/src/components/design-system/Flex/index.tsx
@@ -1,0 +1,1 @@
+export { Flex } from "src/components/design-system/Flex/Flex";

--- a/frontend/src/components/design-system/Grid/Grid.module.css
+++ b/frontend/src/components/design-system/Grid/Grid.module.css
@@ -1,0 +1,22 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  grid-auto-rows: minmax(200px, auto);
+  column-gap: var(--grid-column-gap, var(--space-sm));
+  row-gap: var(--grid-row-gap, var(--space-sm));
+}
+
+.grid[data-gutter="sm"] {
+  --grid-column-gap: var(--space-sm);
+  --grid-row-gap: var(--space-sm);
+}
+
+.grid[data-gutter="md"] {
+  --grid-column-gap: var(--space-md);
+  --grid-row-gap: var(--space-md);
+}
+
+.grid[data-gutter="lg"] {
+  --grid-column-gap: var(--space-lg);
+  --grid-row-gap: var(--space-lg);
+}

--- a/frontend/src/components/design-system/Grid/Grid.tsx
+++ b/frontend/src/components/design-system/Grid/Grid.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { GridItem } from "src/components/design-system/Grid/GridItem";
+import styles from "src/components/design-system/Grid/Grid.module.css";
+
+type GutterSize = "sm" | "md" | "lg";
+
+type GridProps = {
+  gutter?: GutterSize;
+  children: React.ReactNode;
+};
+
+function isValidGridItem(child: React.ReactNode): boolean {
+  if (!React.isValidElement(child)) {
+    return false;
+  }
+
+  const componentType = child.type as React.ComponentType<any>;
+  return (
+    child.type === GridItem ||
+    (componentType && componentType.displayName === "GridItem")
+  );
+}
+
+export function Grid({ gutter = "sm", children }: GridProps) {
+  const childrenArray = React.Children.toArray(children);
+  const invalidChildren = childrenArray.filter(
+    (child) => !isValidGridItem(child)
+  );
+
+  if (invalidChildren.length > 0) {
+    throw new Error(
+      `Grid component only accepts GridItem as direct children. Found ${invalidChildren.length} invalid child(ren).`
+    );
+  }
+
+  return (
+    <div className={styles.grid} data-gutter={gutter}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/design-system/Grid/GridItem.module.css
+++ b/frontend/src/components/design-system/Grid/GridItem.module.css
@@ -1,0 +1,4 @@
+.gridItem {
+  min-width: 0;
+  height: 100%;
+}

--- a/frontend/src/components/design-system/Grid/GridItem.tsx
+++ b/frontend/src/components/design-system/Grid/GridItem.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import styles from "src/components/design-system/Grid/GridItem.module.css";
+
+type GridItemProps = {
+  colSpan?: number;
+  rowSpan?: number;
+  children: React.ReactNode;
+};
+
+export function GridItem({ colSpan = 12, rowSpan = 1, children }: GridItemProps) {
+  if (colSpan < 1 || colSpan > 12) {
+    throw new Error(
+      `GridItem colSpan must be between 1 and 12, received ${colSpan}`
+    );
+  }
+
+  if (rowSpan < 1) {
+    throw new Error(`GridItem rowSpan must be at least 1, received ${rowSpan}`);
+  }
+
+  return (
+    <div
+      className={styles.gridItem}
+      style={{
+        gridColumn: `span ${colSpan}`,
+        gridRow: `span ${rowSpan}`,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+GridItem.displayName = "GridItem";

--- a/frontend/src/components/design-system/Grid/index.tsx
+++ b/frontend/src/components/design-system/Grid/index.tsx
@@ -1,0 +1,2 @@
+export { Grid } from "src/components/design-system/Grid/Grid";
+export { GridItem } from "src/components/design-system/Grid/GridItem";

--- a/frontend/src/components/design-system/Heading/Heading.tsx
+++ b/frontend/src/components/design-system/Heading/Heading.tsx
@@ -1,9 +1,24 @@
 import { useMemo } from "react";
+import { getCSSVariable } from "src/utils/css_util";
+
+export type FontSize =
+  | "xs"
+  | "sm"
+  | "base"
+  | "lg"
+  | "xl"
+  | "2xl"
+  | "3xl"
+  | "4xl"
+  | "5xl"
+  | "6xl";
+
+export type FontWeight = "light" | "normal" | "medium" | "semibold" | "bold";
 
 type HeadingProps = {
   accessbilityLevel: 1 | 2 | 3 | 4 | 5 | 6;
-  weight?: number | string;
-  size?: number | string;
+  weight?: FontWeight;
+  size?: FontSize;
   children: React.ReactNode;
 };
 
@@ -19,6 +34,16 @@ const headingComponents: Record<
   6: "h6",
 };
 
+function getFontSize(size: FontSize | undefined): string | undefined {
+  if (size === undefined) return undefined;
+  return getCSSVariable(`--font-size-${size}`);
+}
+
+function getFontWeight(weight: FontWeight | undefined): string | undefined {
+  if (weight === undefined) return undefined;
+  return getCSSVariable(`--font-weight-${weight}`);
+}
+
 export function Heading({
   accessbilityLevel,
   children,
@@ -29,11 +54,14 @@ export function Heading({
 
   const style = useMemo(() => {
     const styles: React.CSSProperties = {};
-    if (weight !== undefined) {
-      styles.fontWeight = weight;
+    const fontSize = getFontSize(size);
+    const fontWeight = getFontWeight(weight);
+
+    if (fontSize !== undefined) {
+      styles.fontSize = fontSize;
     }
-    if (size !== undefined) {
-      styles.fontSize = size;
+    if (fontWeight !== undefined) {
+      styles.fontWeight = fontWeight;
     }
     return Object.keys(styles).length > 0 ? styles : undefined;
   }, [weight, size]);

--- a/frontend/src/components/design-system/Icon/Icon.tsx
+++ b/frontend/src/components/design-system/Icon/Icon.tsx
@@ -33,6 +33,7 @@ import {
   Key,
   LucideIcon,
   Info,
+  GripVertical,
 } from "lucide-react";
 
 const iconMap: Record<IconType, LucideIcon> = {
@@ -63,6 +64,7 @@ const iconMap: Record<IconType, LucideIcon> = {
   check_square: CheckSquare,
   key: Key,
   info: Info,
+  grip_vertical: GripVertical,
 };
 
 const sizeMap: Record<IconSize, number> = {

--- a/frontend/src/components/design-system/datatypes.tsx
+++ b/frontend/src/components/design-system/datatypes.tsx
@@ -47,7 +47,8 @@ export type IconType =
   | "calendar"
   | "check_square"
   | "key"
-  | "info";
+  | "info"
+  | "grip_vertical";
 
 export type IconSize = "sm" | "md" | "lg";
 
@@ -81,7 +82,11 @@ export type AlignContent =
   | "space-evenly"
   | "stretch";
 
-export type ColorVariant = "default" | "info" | "error" | "warning";
+export type ColorVariant = "default" | "info" | "error" | "warning" | "white";
+
+export type BorderVariant = "default";
+
+export type ShadowVariant = "2xs" | "xs" | "sm" | "md" | "lg" | "xl";
 
 export type Postition = "sticky" | "absolute" | "relative";
 
@@ -111,6 +116,8 @@ export type BoxElement =
 
 export type SharedLayoutProps = {
   borderRadius?: BorderRadius;
+  border?: BorderVariant;
+  shadow?: ShadowVariant;
   color?: ColorVariant;
   direction?: Direction;
   gap?: SpacingSize;

--- a/frontend/src/components/design-system/index.tsx
+++ b/frontend/src/components/design-system/index.tsx
@@ -1,3 +1,6 @@
+export { Box } from "src/components/design-system/Box";
+export { Flex } from "src/components/design-system/Flex";
+export { Grid, GridItem } from "src/components/design-system/Grid";
 export { Button } from "src/components/design-system/Button";
 export { IconButton } from "src/components/design-system/IconButton";
 export {
@@ -9,7 +12,6 @@ export { Heading } from "src/components/design-system/Heading";
 export { Form } from "src/components/design-system/Form";
 export { Select } from "src/components/design-system/Select";
 export type { SelectOption } from "src/components/design-system/Select";
-export { Flex } from "src/components/design-system/Flex/Flex";
 export { Text } from "src/components/design-system/Text";
 export { BannerSlim } from "src/components/design-system/BannerSlim";
 export {

--- a/frontend/src/components/design-system/utils.tsx
+++ b/frontend/src/components/design-system/utils.tsx
@@ -6,6 +6,8 @@ import type {
   SpacingValue,
   SpacingSize,
   NumberString,
+  BorderVariant,
+  ShadowVariant,
 } from "src/components/design-system/datatypes";
 
 export function getFlexStyles(
@@ -92,6 +94,41 @@ function getBorderRadius(borderRadius: string) {
   return getCSSVariable(`--border-radius-${borderRadius}`);
 }
 
+function getBorderStyles(
+  border: BorderVariant | undefined
+): React.CSSProperties {
+  if (border === undefined) return {};
+
+  const borderMapping: Record<BorderVariant, string> = {
+    default: "var(--border-default-thin)",
+  };
+
+  const borderValue = borderMapping[border];
+  if (!borderValue) return {};
+
+  return { border: borderValue };
+}
+
+function getShadowStyles(
+  shadow: ShadowVariant | undefined
+): React.CSSProperties {
+  if (shadow === undefined) return {};
+
+  const shadowMapping: Record<ShadowVariant, string> = {
+    "2xs": "var(--shadow-2xs)",
+    xs: "var(--shadow-xs)",
+    sm: "var(--shadow-sm)",
+    md: "var(--shadow-md)",
+    lg: "var(--shadow-lg)",
+    xl: "var(--shadow-xl)",
+  };
+
+  const shadowValue = shadowMapping[shadow];
+  if (!shadowValue) return {};
+
+  return { boxShadow: shadowValue };
+}
+
 export function getSharedLayoutStyles(
   props: SharedLayoutProps
 ): React.CSSProperties {
@@ -118,6 +155,8 @@ export function getSharedLayoutStyles(
     height,
     width,
     borderRadius,
+    border,
+    shadow,
   } = props;
 
   const gapSize = gap ? getCSSVariable(`--space-${gap}`) : undefined;
@@ -162,6 +201,8 @@ export function getSharedLayoutStyles(
     ...(alignItems && { alignItems }),
     ...(alignContent && { alignContent }),
     ...(borderRadius && { borderRadius: getBorderRadius(borderRadius) }),
+    ...getBorderStyles(border),
+    ...getShadowStyles(shadow),
     ...getFlexStyles(flex),
     ...getOverflowStyles(overflow),
   };

--- a/frontend/src/constants/api_endpoints.tsx
+++ b/frontend/src/constants/api_endpoints.tsx
@@ -15,6 +15,7 @@ export const API_ENDPOINTS = {
     GET_ALL: "/api/v1/notebook",
     GET_BY_ID: "/api/v1/notebook/:id",
     GET_BY_CANVAS_ID: "/api/v1/notebook/canvas/:canvas_id",
+    GET_CELLS_BY_NOTEBOOK_ID: "/api/v1/notebook/:id/cells",
     UPDATE: "/api/v1/notebook/:id",
     DELETE: "/api/v1/notebook/:id",
   },
@@ -31,5 +32,10 @@ export const API_ENDPOINTS = {
     GET_ALL: "/api/v1/canvas",
     GET_BY_ID: "/api/v1/canvas/:id",
     DELETE: "/api/v1/canvas/:id",
+  },
+  DASHBOARD: {
+    GET_BY_ID: "/api/v1/dashboard/:id",
+    GET_BY_CANVAS_ID: "/api/v1/dashboard/canvas/:canvas_id",
+    UPDATE: "/api/v1/dashboard/:id",
   },
 };

--- a/frontend/src/css/index.css
+++ b/frontend/src/css/index.css
@@ -230,7 +230,7 @@ button {
 
   /* Border Colors */
   --border-color-default: var(--color-grey-500);
-  --border-color-light: var(--color-grey-400);
+  --border-color-light: var(--color-grey-200);
   --border-color-dark: var(--color-grey-700);
   --border-color-focus: var(--color-primary-500);
   --border-color-error: var(--color-red-dark-2);
@@ -241,10 +241,6 @@ button {
     var(--border-color-default);
   --border-input-focus: var(--border-width-medium) var(--border-style-solid)
     var(--border-color-focus);
-  --border-input-error: var(--border-width-medium) var(--border-style-solid)
-    var(--border-color-error);
-  --border-input-hide: var(--border-width-medium) var(--border-style-solid)
-    var(--color-background);
 
   --border-section: var(--border-width-medium) var(--border-style-solid)
     var(--border-color-default);
@@ -252,14 +248,18 @@ button {
     var(--border-color-light);
   --border-cell: var(--border-width-medium) var(--border-style-solid)
     var(--border-color-default);
-
   --border-table-cell: var(--border-width-thin) var(--border-style-solid)
     var(--border-color-light);
-
   --border-divider: var(--border-width-thin) var(--border-style-solid)
     var(--border-color-light);
   --border-separator: var(--border-width-thin) var(--border-style-dashed)
     var(--border-color-default);
+  --border-default-thin: var(--border-width-thin) var(--border-style-solid)
+    var(--border-color-light);
+  --border-default-medium: var(--border-width-medium) var(--border-style-solid)
+    var(--border-color-light);
+  --border-primary-medium: var(--border-width-medium) var(--border-style-solid)
+    var(--color-primary-200);
 
   /* Border Radius */
   --border-radius-none: 0;
@@ -283,6 +283,8 @@ button {
   --icon-2xl: 3rem;
 
   /* Shadow System */
+  --shadow-2xs:
+    0 1px 2px hsla(0, 0%, 0%, 0.08), 0 1px 1px hsla(0, 0%, 0%, 0.12);
   --shadow-xs: 0 1px 3px hsla(0, 0%, 0%, 0.12), 0 1px 2px hsla(0, 0%, 0%, 0.24);
   --shadow-sm: 0 3px 6px hsla(0, 0%, 0%, 0.15), 0 2px 4px hsla(0, 0%, 0%, 0.12);
   --shadow-md:


### PR DESCRIPTION
- Introduce a new Dashboard component for managing and displaying dashboard layouts.
- Add API endpoints for creating, updating, and retrieving dashboards by canvas ID.
- Implement layout serialization and deserialization for dashboard components.
- Enhance the UI with a grid layout using react-grid-layout for dynamic positioning of dashboard elements.
- Refactor existing services and DTOs to accommodate new dashboard features and layout management.

Refs: #44