### PR TITLE
Connections list pagination

### DIFF
--- a/frontend/src/components/Connection/ConnectionsTable/ConnectionsTable.tsx
+++ b/frontend/src/components/Connection/ConnectionsTable/ConnectionsTable.tsx
@@ -11,7 +11,11 @@ import {
   useConnections,
   useDeleteConnection,
 } from "src/api/connection/queries";
-import { SophoTable, ColumnConfig } from "src/components/SophoTable/SophoTable";
+import {
+  DataTable,
+  TableType,
+  ColumnConfig,
+} from "src/components/design-system/DataTable";
 import { formatTimestamp } from "src/utils/timestamp_utils";
 
 export function ConnectionsTable() {
@@ -108,11 +112,14 @@ export function ConnectionsTable() {
 
   return (
     <div className={ConnectionsStyles.connectionsTable}>
-      <SophoTable
+      <DataTable
+        tableType={TableType.CLIENT_SIDE_PAGINATED}
         columns={columns}
         data={connectionsData ?? []}
         isLoading={isLoading}
         isError={isError}
+        enableColumnResizing={false}
+        getRowId={(row) => row.id}
       />
     </div>
   );


### PR DESCRIPTION
Replace ConnectionsTable with design-system DataTable to enable client-side pagination.

---
<a href="https://cursor.com/background-agent?bcId=bc-80759743-6161-4141-a307-6cf07f8532ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80759743-6161-4141-a307-6cf07f8532ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

