### PR TITLE
chore(frontend): editor and DataTable enhancements

### DIFF
--- a/frontend/src/components/design-system/DataTable/DataTable.module.css
+++ b/frontend/src/components/design-system/DataTable/DataTable.module.css
@@ -4,7 +4,6 @@
   flex-direction: column;
   gap: var(--space-sm);
   flex: 1;
-  /* justify-content: space-between; */
 }
 
 .tableContainer {
@@ -16,14 +15,13 @@
   gap: var(--space-sm);
   border-radius: var(--border-radius-lg);
   border: var(--border-dark-thin);
-  width: fit-content;
-  max-width: 100%;
 }
 
 .table {
   border-collapse: collapse;
   box-shadow: var(--shadow);
-  table-layout: fixed;
+  table-layout: auto;
+  width: 100%;
 }
 
 .tableHeaderCell,
@@ -41,7 +39,7 @@
   position: sticky;
   top: 0px;
   border-left: var(--border-dark-thin);
-  padding: var(--space-xs) var(--space-xs) var(--space-xs) var(--space-2xs);
+  padding: var(--space-sm) var(--space-md);
   user-select: none;
   background-color: var(--color-grey-100);
   box-shadow: 0 var(--border-width-thin) 0 0 var(--color-grey-300);
@@ -52,7 +50,7 @@
 }
 
 .tableDataCell {
-  padding: var(--space-2xs);
+  padding: var(--space-sm) var(--space-md);
   border-bottom: var(--border-dark-thin);
   border-left: var(--border-dark-thin);
   font-size: var(--font-size-sm);

--- a/frontend/src/components/design-system/DataTable/DataTable.tsx
+++ b/frontend/src/components/design-system/DataTable/DataTable.tsx
@@ -79,12 +79,7 @@ export function DataTable<T>({
           isResizingColumn ? styles.isResizingColumn : ""
         }`}
       >
-        <table
-          className={styles.table}
-          style={{
-            width: table.getCenterTotalSize(),
-          }}
-        >
+        <table className={styles.table}>
           <TableHeader
             headerGroups={table.getHeaderGroups()}
             columnConfigMap={columnConfigMap}

--- a/frontend/src/components/design-system/DataTable/utils.tsx
+++ b/frontend/src/components/design-system/DataTable/utils.tsx
@@ -20,7 +20,7 @@ import styles from "src/components/design-system/DataTable/DataTable.module.css"
 
 export function getAlignmentClass(
   dataType: ColumnDataType | undefined,
-  cellValue: any,
+  cellValue: any
 ): string {
   if (!dataType) {
     return styles.cellAlignLeft;
@@ -43,7 +43,7 @@ export function getAlignmentClass(
 }
 
 export function getHeaderAlignmentClass(
-  dataType: ColumnDataType | undefined,
+  dataType: ColumnDataType | undefined
 ): string {
   if (!dataType) {
     return styles.cellAlignLeft;
@@ -62,7 +62,7 @@ export function getHeaderAlignmentClass(
 }
 
 export function getHeaderJustifyContent(
-  dataType: ColumnDataType | undefined,
+  dataType: ColumnDataType | undefined
 ): "flex-start" | "flex-end" {
   if (!dataType) {
     return "flex-start";
@@ -109,7 +109,7 @@ export function createReactTable<T>(
   pagination: PaginationState | undefined,
   setPagination: any | undefined,
   enableColumnResizing: boolean = true,
-  getRowId?: (row: T) => string,
+  getRowId?: (row: T) => string
 ) {
   switch (tableType) {
     case TableType.FULL: {
@@ -130,9 +130,9 @@ export function createReactTable<T>(
         columnResizeMode: "onChange",
         columnResizeDirection: "ltr",
         enableColumnResizing: enableColumnResizing,
-        defaultColumn: {
-          minSize: 200,
-        },
+        // defaultColumn: {
+        //   minSize: 200,
+        // },
         ...(getRowId && { getRowId }),
       });
     }
@@ -157,7 +157,7 @@ export function createReactTable<T>(
     case TableType.CLIENT_SIDE_PAGINATED: {
       if (!pagination) {
         throw Error(
-          "Pagination state is required for client-side paginated table",
+          "Pagination state is required for client-side paginated table"
         );
       }
       return useReactTable({
@@ -193,7 +193,7 @@ export function renderPaginationControl<T>(
   tableType: TableType,
   paginationConfig: PaginationConfig | undefined,
   table: Table<T>,
-  showRowsPerPage: boolean = true,
+  showRowsPerPage: boolean = true
 ): React.ReactNode {
   const onChangePageSize = (newPageSize: string) => {
     table.setPageSize(Number(newPageSize));


### PR DESCRIPTION
## Summary

Editor and DataTable improvements for consistent theming and layout.

## Changes

### Notebook cell editor theme refactor
- Extract CodeMirror styling from global CSS to dedicated theme module
- Add `theme.tsx` with EditorView.theme and syntax highlighting
- Use design system CSS variables for consistent theming
- Remove `CellEditor.global.css`
- Update active cell outline styling

### DataTable layout and styling
- Switch from `table-layout: fixed` to `auto` for better column flexibility
- Remove explicit table width (`table.getCenterTotalSize`) for full-width layout
- Standardize cell padding to `space-sm` / `space-md` for consistency
- Remove tableContainer width constraints
- Code formatting cleanup in utils

## Context

These changes improve the editor experience by centralizing theme configuration and fix DataTable layout issues where fixed layout and explicit width calculations could cause unexpected column behavior.

## Breaking changes

None.
