### PR TITLE
feat: Add clear cell output and home empty states

### DIFF
--- a/backend/src/cell/service.rs
+++ b/backend/src/cell/service.rs
@@ -5,6 +5,7 @@ use crate::cell::dto;
 use crate::cell::dto::CellContent;
 use crate::cell::repository;
 use crate::common::database_utils;
+use crate::common::error_codes::codes;
 use crate::common::errors::SophoError;
 use crate::common::time_utils;
 use crate::common::AppState;
@@ -448,9 +449,19 @@ async fn execute_query_and_format_results(
     let result = sqlx::query(query).fetch_all(&mut database_connection).await;
     let rows = match result {
         Ok(rows) => rows,
-        Err(e) => {
+        Err(sqlx::Error::Database(e)) => {
             return (
                 StatusCode::BAD_REQUEST,
+                axum::Json(serde_json::json!({
+                    "status": StatusCode::BAD_REQUEST.as_u16(),
+                    "code": codes::SYNTAX_ERROR.as_str(),
+                    "message": e.to_string()
+                })),
+            );
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
                 axum::Json(serde_json::json!({ "error": e.to_string() })),
             );
         }
@@ -734,7 +745,11 @@ async fn execute_sql_cell(
         None => {
             return (
                 StatusCode::PRECONDITION_FAILED,
-                axum::Json(serde_json::json!({ "error": "Cell has no connection assigned" })),
+                axum::Json(serde_json::json!({
+                    "status": StatusCode::PRECONDITION_FAILED.as_u16(),
+                    "code": codes::MISSING_PREREQUISITES.as_str(),
+                    "message": "Choose a connection"
+                })),
             );
         }
     };

--- a/backend/src/common/error_codes.rs
+++ b/backend/src/common/error_codes.rs
@@ -6,6 +6,8 @@ pub enum ErrorCode {
     AccessTokenExpired,
     RefreshTokenExpired,
     InvalidAccessToken,
+    MissingPrerequisites,
+    SyntaxError,
 }
 
 impl ErrorCode {
@@ -16,6 +18,8 @@ impl ErrorCode {
             ErrorCode::AccessTokenExpired => "ACCESS_TOKEN_EXPIRED",
             ErrorCode::RefreshTokenExpired => "REFRESH_TOKEN_EXPIRED",
             ErrorCode::InvalidAccessToken => "INVALID_ACCESS_TOKEN",
+            ErrorCode::MissingPrerequisites => "MISSING_PREREQUISITES",
+            ErrorCode::SyntaxError => "SYNTAX_ERROR",
         }
     }
 
@@ -39,4 +43,6 @@ pub mod codes {
     pub const ACCESS_TOKEN_EXPIRED: ErrorCode = ErrorCode::AccessTokenExpired;
     pub const REFRESH_TOKEN_EXPIRED: ErrorCode = ErrorCode::RefreshTokenExpired;
     pub const INVALID_ACCESS_TOKEN: ErrorCode = ErrorCode::InvalidAccessToken;
+    pub const MISSING_PREREQUISITES: ErrorCode = ErrorCode::MissingPrerequisites;
+    pub const SYNTAX_ERROR: ErrorCode = ErrorCode::SyntaxError;
 }

--- a/frontend/src/api/cell/index.tsx
+++ b/frontend/src/api/cell/index.tsx
@@ -5,5 +5,7 @@ export {
   useDeleteCell,
   useExecuteCell,
   useExecuteCellPreview,
+  useCellExecutionResult,
+  useClearCellOutput,
   useReorderCell,
 } from "src/api/cell/queries";

--- a/frontend/src/api/cell/queries.tsx
+++ b/frontend/src/api/cell/queries.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { ApiService } from "src/utils/api_client";
 import { API_ENDPOINTS } from "src/constants/api_endpoints";
@@ -5,6 +6,7 @@ import {
   CellDto,
   CreateCellDto,
   ExecuteCellResponseDto,
+  CellExecutionResultDto,
 } from "src/components/Notebook/Cell/dto";
 import { notebookKeys } from "src/api/notebook/queries";
 import { dashboardKeys } from "src/api/dashboard/queries";
@@ -15,12 +17,16 @@ export const cellKeys = {
   list: (filters: string) => [...cellKeys.lists(), { filters }] as const,
   details: () => [...cellKeys.all, "detail"] as const,
   detail: (id: string) => [...cellKeys.details(), id] as const,
+  execution: (cellId: string) =>
+    [...cellKeys.all, "execution", cellId] as const,
 };
 
 const cellApi = {
   getCell: async (cellId: string): Promise<CellDto> => {
     const response = await ApiService.get({
-      url: API_ENDPOINTS.CELL.GET_BY_ID?.replace(":id", cellId) || `/cells/${cellId}`,
+      url:
+        API_ENDPOINTS.CELL.GET_BY_ID?.replace(":id", cellId) ||
+        `/cells/${cellId}`,
       onlyBody: true,
     });
     return response as CellDto;
@@ -170,6 +176,9 @@ export const useDeleteCell = (notebookId?: string, canvasId?: string) => {
       queryClient.removeQueries({
         queryKey: cellKeys.detail(cellId),
       });
+      queryClient.removeQueries({
+        queryKey: cellKeys.execution(cellId),
+      });
 
       if (notebookId) {
         queryClient.invalidateQueries({
@@ -190,23 +199,62 @@ export const useDeleteCell = (notebookId?: string, canvasId?: string) => {
 };
 
 export const useExecuteCell = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: cellApi.executeCell,
-    onSuccess: () => {},
-    onError: (error) => {
-      console.error("Failed to execute cell:", error);
+    onSuccess: (data, cellId) => {
+      queryClient.setQueryData(cellKeys.execution(cellId), {
+        status: "success",
+        data: data,
+      } satisfies CellExecutionResultDto);
+    },
+    onError: (error, cellId) => {
+      queryClient.setQueryData(cellKeys.execution(cellId), {
+        status: "error",
+        error: error,
+      } satisfies CellExecutionResultDto);
     },
   });
 };
 
 export const useExecuteCellPreview = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: cellApi.executeCellPreview,
-    onSuccess: () => {},
-    onError: (error) => {
-      console.error("Failed to execute cell preview:", error);
+    onSuccess: (data, { cellId }) => {
+      queryClient.setQueryData(cellKeys.execution(cellId), {
+        status: "success",
+        data: data,
+      } satisfies CellExecutionResultDto);
+    },
+    onError: (error, { cellId }) => {
+      queryClient.setQueryData(cellKeys.execution(cellId), {
+        status: "error",
+        error: error,
+      } satisfies CellExecutionResultDto);
     },
   });
+};
+
+export const useCellExecutionResult = (cellId: string) => {
+  return useQuery<CellExecutionResultDto>({
+    queryKey: cellKeys.execution(cellId),
+    queryFn: () =>
+      Promise.reject(new Error("Execution results are cache-only")),
+    enabled: false,
+  });
+};
+
+export const useClearCellOutput = () => {
+  const queryClient = useQueryClient();
+  return useCallback(
+    (cellId: string) => {
+      queryClient.setQueryData(cellKeys.execution(cellId), null);
+    },
+    [queryClient]
+  );
 };
 
 export const useReorderCell = (canvasId?: string) => {

--- a/frontend/src/api/dto.tsx
+++ b/frontend/src/api/dto.tsx
@@ -13,3 +13,32 @@ export type PaginatedData<T> = {
   pageSize: number;
   totalItems: number;
 };
+
+export type ApiErrorBody = {
+  status?: number;
+  code?: string;
+  message?: string;
+  details?: string;
+};
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body: ApiErrorBody,
+    message?: string
+  ) {
+    super(
+      message ?? body.message ?? body.message ?? `Request failed with ${status}`
+    );
+    this.name = "ApiError";
+  }
+
+  get code(): string | undefined {
+    return this.body.code;
+  }
+
+  get message(): string {
+    return this.body.message ?? this.body.message ?? "";
+  }
+}
+

--- a/frontend/src/assets/icons/execute.svg
+++ b/frontend/src/assets/icons/execute.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="48px" viewBox="0 -960 960 960" width="48px" fill="#008000"><path d="M323.5-208.5v-549l431 274.5-431 274.5Z"/></svg>

--- a/frontend/src/components/Canvases/Canvas/Canvas.tsx
+++ b/frontend/src/components/Canvases/Canvas/Canvas.tsx
@@ -69,7 +69,7 @@ export function Canvas() {
   return (
     <Flex
       direction="column"
-      paddingX="md"
+      paddingX="2xl"
       paddingY="md"
       gap="md"
       flex="grow"

--- a/frontend/src/components/Chart/PieChart/PieChart.tsx
+++ b/frontend/src/components/Chart/PieChart/PieChart.tsx
@@ -52,20 +52,20 @@ export const PieChart = ({ category, value, data }: PieChartProps) => {
   const renderLabelContent = useCallback(
     (props: { viewBox?: unknown }) => {
       const vb = (props.viewBox ?? {}) as
-                | { cx?: number; cy?: number }
-                | { x?: number; y?: number; width?: number; height?: number };
-              const x =
-                "cx" in vb && vb.cx != null
-                  ? vb.cx
-                  : "x" in vb && vb.width != null
-                    ? (vb.x ?? 0) + vb.width / 2
-                    : 0;
-              const y =
-                "cy" in vb && vb.cy != null
-                  ? vb.cy
-                  : "y" in vb && vb.height != null
-                    ? (vb.y ?? 0) + vb.height / 2
-                    : 0;
+        | { cx?: number; cy?: number }
+        | { x?: number; y?: number; width?: number; height?: number };
+      const x =
+        "cx" in vb && vb.cx != null
+          ? vb.cx
+          : "x" in vb && vb.width != null
+            ? (vb.x ?? 0) + vb.width / 2
+            : 0;
+      const y =
+        "cy" in vb && vb.cy != null
+          ? vb.cy
+          : "y" in vb && vb.height != null
+            ? (vb.y ?? 0) + vb.height / 2
+            : 0;
       return (
         <text
           x={x}
@@ -99,11 +99,7 @@ export const PieChart = ({ category, value, data }: PieChartProps) => {
           nameKey={category}
           paddingAngle={1}
         >
-          <Label
-            position="center"
-            fill="#666"
-            content={renderLabelContent}
-          />
+          <Label position="center" fill="#666" content={renderLabelContent} />
         </Pie>
         <ChartLegend position="right" />
         <ChartTooltip />

--- a/frontend/src/components/Dashboard/ChartBrowser/ChartBrowser.tsx
+++ b/frontend/src/components/Dashboard/ChartBrowser/ChartBrowser.tsx
@@ -60,7 +60,8 @@ export function ChartBrowser() {
         header: "Chart Type",
         type: "accessor",
         accessor: "chartType",
-        cell: (props) => (props.getValue() as string | null | undefined) || "N/A",
+        cell: (props) =>
+          (props.getValue() as string | null | undefined) || "N/A",
       },
     ],
     []
@@ -77,7 +78,7 @@ export function ChartBrowser() {
       paddingX="sm"
       paddingY="sm"
       shadow="2xs"
-      width="20%"
+      width="30%"
     >
       <DataTable
         tableType={TableType.CLIENT_SIDE_PAGINATED}
@@ -89,6 +90,7 @@ export function ChartBrowser() {
         enableColumnResizing={false}
         enableRowDragging={true}
         getRowId={getRowId}
+        emptyMessage="All cells are added on the dashboard !"
       />
     </Flex>
   );

--- a/frontend/src/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/components/Dashboard/Dashboard.tsx
@@ -64,26 +64,26 @@ export function Dashboard() {
 
   const handleOnDrop = useCallback(
     (droppedLayout: Layout[], itemLayout: Layout, e: DragEvent) => {
-    if (!e.dataTransfer) {
-      return;
-    }
-    const cellId = e.dataTransfer.getData("text/plain");
-    const latestLayout = useStore.getState().dashboard.layout;
-    const existingIds = new Set(latestLayout.map((item) => item.i));
-    const newLayout = droppedLayout.map((item) => {
-      const isNewItem = !existingIds.has(cellId);
-      const matchesPosition =
-        item.x === itemLayout.x &&
-        item.y === itemLayout.y &&
-        item.w === itemLayout.w &&
-        item.h === itemLayout.h;
-      if (isNewItem && matchesPosition) {
-        return { ...item, i: cellId };
+      if (!e.dataTransfer) {
+        return;
       }
-      return item;
-    });
-    setLayout(newLayout);
-  },
+      const cellId = e.dataTransfer.getData("text/plain");
+      const latestLayout = useStore.getState().dashboard.layout;
+      const existingIds = new Set(latestLayout.map((item) => item.i));
+      const newLayout = droppedLayout.map((item) => {
+        const isNewItem = !existingIds.has(cellId);
+        const matchesPosition =
+          item.x === itemLayout.x &&
+          item.y === itemLayout.y &&
+          item.w === itemLayout.w &&
+          item.h === itemLayout.h;
+        if (isNewItem && matchesPosition) {
+          return { ...item, i: cellId };
+        }
+        return item;
+      });
+      setLayout(newLayout);
+    },
     [setLayout]
   );
 

--- a/frontend/src/components/Dashboard/DashboardChart.tsx
+++ b/frontend/src/components/Dashboard/DashboardChart.tsx
@@ -1,7 +1,7 @@
-import { useCell, useExecuteCell } from "src/api/cell";
+import { useCell, useExecuteCell, useCellExecutionResult } from "src/api/cell";
 import { BarChart, ChartType, LineChart, PieChart } from "../Chart";
 import { getChartContent } from "../Notebook/Cell";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import {
   ExecuteCellResponseDto,
   BarChartContent,
@@ -9,7 +9,13 @@ import {
   PieChartContent,
   getChartType,
 } from "../Notebook/Cell/dto";
-import { Flex, Heading, Icon, IconButton } from "src/components/design-system";
+import {
+  BannerSlim,
+  Flex,
+  Heading,
+  Icon,
+  IconButton,
+} from "src/components/design-system";
 import { useStore, DashboardMode } from "src/store";
 import styles from "src/components/Dashboard/Dashboard.module.css";
 
@@ -76,22 +82,17 @@ function ChartRenderer({
 function DashboardChartWithQuery({ cellId }: DashboardChartProps) {
   const cellQuery = useCell(cellId);
   const executeCellMutation = useExecuteCell();
+  const { data: output } = useCellExecutionResult(cellId);
   const chartContent =
     cellQuery && cellQuery.data ? getChartContent(cellQuery.data) : null;
-  const [output, setOutput] = useState<ExecuteCellResponseDto | null>(null);
   const mode = useStore((state) => state.dashboard.mode);
   const getLayout = useStore((state) => state.dashboard.getLayout);
   const setLayout = useStore((state) => state.dashboard.setLayout);
   const isEditing = mode === DashboardMode.EDITING;
 
   useEffect(() => {
-    executeCellMutation.mutate(cellId, {
-      onSuccess: (data) => {
-        setOutput(data);
-      },
-      onError: () => {},
-    });
-  }, [cellId, executeCellMutation]);
+    executeCellMutation.mutate(cellId);
+  }, [cellId, executeCellMutation.mutate]);
 
   const isLoading =
     cellQuery == null ||
@@ -107,13 +108,8 @@ function DashboardChartWithQuery({ cellId }: DashboardChartProps) {
   }, [cellId, getLayout, setLayout]);
 
   const handleRefresh = useCallback(() => {
-    executeCellMutation.mutate(cellId, {
-      onSuccess: (data) => {
-        setOutput(data);
-      },
-      onError: () => {},
-    });
-  }, [cellId, executeCellMutation]);
+    executeCellMutation.mutate(cellId);
+  }, [cellId, executeCellMutation.mutate]);
 
   return (
     <Flex
@@ -162,8 +158,23 @@ function DashboardChartWithQuery({ cellId }: DashboardChartProps) {
         </Flex>
       </Flex>
 
-      {!isLoading && (
-        <ChartRenderer chartContent={chartContent} output={output} />
+      {output && output.status === "error" && (
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          paddingX="lg"
+          paddingY="lg"
+          height="100%"
+        >
+          <BannerSlim
+            type="error"
+            message={`Check errors in ${cellQuery.data?.name}: ${output.error.message}.`}
+          />
+        </Flex>
+      )}
+
+      {!isLoading && output?.status === "success" && output.data && (
+        <ChartRenderer chartContent={chartContent} output={output.data} />
       )}
     </Flex>
   );

--- a/frontend/src/components/Home/Home.tsx
+++ b/frontend/src/components/Home/Home.tsx
@@ -1,5 +1,5 @@
 import { Flex, Heading } from "src/components/design-system";
-import { HomeHeader, RecentlyUpdatedCanvases } from "./components";
+import { HomeHeader, HomeEmptyState, RecentlyUpdatedCanvases } from "./components";
 
 export function Home() {
   return (
@@ -8,6 +8,7 @@ export function Home() {
       <Flex paddingX="lg" direction="column" gap="lg">
         <Heading accessbilityLevel={1}>Home</Heading>
         <RecentlyUpdatedCanvases />
+        <HomeEmptyState />
       </Flex>
     </Flex>
   );

--- a/frontend/src/components/Home/components/EmptyState/CanvasesEmptyState.tsx
+++ b/frontend/src/components/Home/components/EmptyState/CanvasesEmptyState.tsx
@@ -1,0 +1,19 @@
+import { EmptyState } from "./EmptyState";
+
+type CanvasesEmptyStateProps = {
+  onCreateCanvas: () => void;
+};
+
+export function CanvasesEmptyState({
+  onCreateCanvas,
+}: CanvasesEmptyStateProps) {
+  return (
+    <EmptyState
+      icon="layers"
+      heading="No canvases yet"
+      description="Create a canvas to build notebooks, dashboards and explore data"
+      buttonLabel="New Canvas"
+      onButtonClick={onCreateCanvas}
+    />
+  );
+}

--- a/frontend/src/components/Home/components/EmptyState/ConnectionsEmptyState.tsx
+++ b/frontend/src/components/Home/components/EmptyState/ConnectionsEmptyState.tsx
@@ -1,0 +1,19 @@
+import { EmptyState } from "./EmptyState";
+
+type ConnectionsEmptyStateProps = {
+  onCreateConnection: () => void;
+};
+
+export function ConnectionsEmptyState({
+  onCreateConnection,
+}: ConnectionsEmptyStateProps) {
+  return (
+    <EmptyState
+      icon="plug"
+      heading="No connections yet"
+      description="Connect your data sources to build notebooks, dashboards and explore data"
+      buttonLabel="New Connection"
+      onButtonClick={onCreateConnection}
+    />
+  );
+}

--- a/frontend/src/components/Home/components/EmptyState/EmptyState.tsx
+++ b/frontend/src/components/Home/components/EmptyState/EmptyState.tsx
@@ -1,0 +1,58 @@
+import {
+  Button,
+  Flex,
+  Heading,
+  Icon,
+  Text,
+} from "src/components/design-system";
+import { IconType } from "src/components/design-system/datatypes";
+
+type EmptyStateProps = {
+  icon: IconType;
+  heading: string;
+  description: string;
+  buttonLabel: string;
+  onButtonClick: () => void;
+};
+
+export function EmptyState({
+  icon,
+  heading,
+  description,
+  buttonLabel,
+  onButtonClick,
+}: EmptyStateProps) {
+  return (
+    <Flex
+      as="section"
+      direction="column"
+      gap="md"
+      alignItems="center"
+      alignSelf="center"
+      paddingY="lg"
+      paddingX="lg"
+    >
+      <Icon type={icon} color="lightgrey" size="2xl" interactive={false} />
+      <Flex
+        direction="column"
+        gap="xs"
+        alignItems="center"
+        sx={{ textAlign: "center" }}
+      >
+        <Heading accessbilityLevel={2} textColor="default">
+          {heading}
+        </Heading>
+        <Text as="p" color="subtle">
+          {description}
+        </Text>
+      </Flex>
+      <Button
+        backgroundColor="accent"
+        label={buttonLabel}
+        onClick={onButtonClick}
+        shape="rectangle"
+        size="md"
+      />
+    </Flex>
+  );
+}

--- a/frontend/src/components/Home/components/EmptyState/HomeEmptyState.tsx
+++ b/frontend/src/components/Home/components/EmptyState/HomeEmptyState.tsx
@@ -1,0 +1,23 @@
+import {
+  useHomeNavigation,
+  useIsCanvasesEmptyState,
+  useIsConnectionsEmptyState,
+} from "../../hooks";
+import { CanvasesEmptyState } from "./CanvasesEmptyState";
+import { ConnectionsEmptyState } from "./ConnectionsEmptyState";
+
+export function HomeEmptyState() {
+  const { handleCreateCanvas, handleCreateConnection } = useHomeNavigation();
+  const isConnectionsEmptyState = useIsConnectionsEmptyState();
+  const isCanvasesEmptyState = useIsCanvasesEmptyState();
+
+  if (isConnectionsEmptyState) {
+    return (
+      <ConnectionsEmptyState onCreateConnection={handleCreateConnection} />
+    );
+  }
+  if (isCanvasesEmptyState) {
+    return <CanvasesEmptyState onCreateCanvas={handleCreateCanvas} />;
+  }
+  return null;
+}

--- a/frontend/src/components/Home/components/EmptyState/index.ts
+++ b/frontend/src/components/Home/components/EmptyState/index.ts
@@ -1,0 +1,4 @@
+export { EmptyState } from "./EmptyState";
+export { CanvasesEmptyState } from "./CanvasesEmptyState";
+export { ConnectionsEmptyState } from "./ConnectionsEmptyState";
+export { HomeEmptyState } from "./HomeEmptyState";

--- a/frontend/src/components/Home/components/RecentlyUpdatedCanvases.tsx
+++ b/frontend/src/components/Home/components/RecentlyUpdatedCanvases.tsx
@@ -1,14 +1,15 @@
 import { Flex, Heading, Grid, GridItem } from "src/components/design-system";
 import { CanvasCard } from "./CanvasCard";
-import { useRecentlyUpdatedCanvases } from "../hooks";
+import { useIsEmptyState, useRecentlyUpdatedCanvases } from "../hooks";
 
 const GRID_GUTTER = { base: "md", md: "lg" } as const;
 const GRID_COL_SPAN = { base: 1, md: 4 } as const;
 
 export function RecentlyUpdatedCanvases() {
   const canvasesQuery = useRecentlyUpdatedCanvases(0, 9);
+  const isEmptyState = useIsEmptyState();
 
-  if (!canvasesQuery.data?.data) {
+  if (isEmptyState || !canvasesQuery.data?.data) {
     return null;
   }
 

--- a/frontend/src/components/Home/components/index.tsx
+++ b/frontend/src/components/Home/components/index.tsx
@@ -1,5 +1,6 @@
 export { HomeHeader } from "./HomeHeader";
 export { RecentlyUpdatedCanvases } from "./RecentlyUpdatedCanvases";
+export { HomeEmptyState } from "./EmptyState";
 export { CanvasCard } from "./CanvasCard";
 export { CanvasStats } from "./CanvasStats";
 export { CanvasStatItem } from "./CanvasStatItem";

--- a/frontend/src/components/Home/hooks.tsx
+++ b/frontend/src/components/Home/hooks.tsx
@@ -5,6 +5,7 @@ import { CanvasesPageState } from "src/components/Canvases/dto";
 import { ConnectionDetailsPageStateEnum } from "src/components/Connection/dto";
 import { APP_ROUTES } from "src/constants/app_routes";
 import { useAllCanvases } from "src/api/canvas/queries";
+import { useConnections } from "src/api/connection";
 
 export function useHomeNavigation() {
   const navigate = useNavigate();
@@ -37,3 +38,19 @@ export function useRecentlyUpdatedCanvases(
 ) {
   return useAllCanvases(page, pageSize);
 }
+
+export const useIsConnectionsEmptyState = (): boolean | undefined => {
+  const connectionsQuery = useConnections();
+  return connectionsQuery.data?.length === 0;
+};
+
+export const useIsCanvasesEmptyState = (): boolean | undefined => {
+  const canvasesQuery = useAllCanvases();
+  return canvasesQuery.data?.totalItems === 0;
+};
+
+export const useIsEmptyState = (): boolean | undefined => {
+  const isConnectionsEmptyState = useIsConnectionsEmptyState();
+  const isCanvasesEmptyState = useIsCanvasesEmptyState();
+  return isConnectionsEmptyState || isCanvasesEmptyState;
+};

--- a/frontend/src/components/Notebook/Cell/dto.tsx
+++ b/frontend/src/components/Notebook/Cell/dto.tsx
@@ -1,10 +1,8 @@
+import { ApiErrorBody } from "src/api/dto";
 import { ChartType } from "src/components/Chart";
 import { ColumnDataType } from "src/constants/database_types";
 
 export enum CellType {
-  TEXT = "TEXT",
-  CODE = "CODE",
-  MARKDOWN = "MARKDOWN",
   SQL = "SQL",
   CHART = "CHART",
 }
@@ -96,6 +94,10 @@ export type ExecuteCellResponseDto = {
   columns: Array<{ column_name: string; data_type: ColumnDataType }> | null;
   data: Record<string, unknown>[] | null;
 };
+
+export type CellExecutionResultDto =
+  | { status: "success"; data: ExecuteCellResponseDto }
+  | { status: "error"; error: ApiErrorBody };
 
 export function getChartContent(cell: CellDto): ChartContent | null {
   if (cell.cell_type !== CellType.CHART || !cell.content) {

--- a/frontend/src/components/Notebook/Cell/hooks.tsx
+++ b/frontend/src/components/Notebook/Cell/hooks.tsx
@@ -1,36 +1,20 @@
 import { useExecuteCell, useExecuteCellPreview } from "src/api/cell";
-import { useStore } from "src/store";
-import {
-  ExecutionState,
-  CellOutputState,
-} from "src/components/Notebook/Cell/dto";
 
 export function useHandleExecuteCell() {
-  const setOutput = useStore((state) => state.cell.setOutput);
-  const setExecutionState = useStore((state) => state.cell.setExecutionState);
-  const setOutputState = useStore((state) => state.cell.setOutputState);
   const executeCellMutation = useExecuteCell();
 
   return (
     cellId: string,
-    shouldSetOutputState: boolean = true,
     onSuccessCallback: (() => void) | null = null,
     onErrorCallback: (() => void) | null = null
   ) => {
-    setExecutionState(cellId, ExecutionState.RUNNING);
     executeCellMutation.mutate(cellId, {
-      onSuccess: (data) => {
-        setOutput(cellId, data);
-        setExecutionState(cellId, ExecutionState.COMPLETED);
-        if (data != null && shouldSetOutputState) {
-          setOutputState(cellId, CellOutputState.PRESENT);
-        }
+      onSuccess: () => {
         if (onSuccessCallback) {
           onSuccessCallback();
         }
       },
-      onError: () => {
-        setExecutionState(cellId, ExecutionState.FAILED);
+      onError: (error) => {
         if (onErrorCallback) {
           onErrorCallback();
         }
@@ -40,9 +24,6 @@ export function useHandleExecuteCell() {
 }
 
 export function useHandleExecuteCellPreview() {
-  const setOutput = useStore((state) => state.cell.setOutput);
-  const setExecutionState = useStore((state) => state.cell.setExecutionState);
-  const setOutputState = useStore((state) => state.cell.setOutputState);
   const executeCellPreviewMutation = useExecuteCellPreview();
 
   return (
@@ -52,20 +33,13 @@ export function useHandleExecuteCellPreview() {
     onSuccessCallback?: () => void,
     onErrorCallback?: () => void
   ) => {
-    setExecutionState(cellId, ExecutionState.RUNNING);
     executeCellPreviewMutation.mutate(
       { cellId, content, cellType },
       {
-        onSuccess: (data) => {
-          setOutput(cellId, data);
-          setExecutionState(cellId, ExecutionState.COMPLETED);
-          if (data != null) {
-            setOutputState(cellId, CellOutputState.PRESENT);
-          }
+        onSuccess: () => {
           onSuccessCallback?.();
         },
         onError: () => {
-          setExecutionState(cellId, ExecutionState.FAILED);
           onErrorCallback?.();
         },
       }

--- a/frontend/src/components/Notebook/CellEditor/CellEditor.tsx
+++ b/frontend/src/components/Notebook/CellEditor/CellEditor.tsx
@@ -36,16 +36,28 @@ import { KeyBinding } from "@codemirror/view";
 import { lintKeymap } from "@codemirror/lint";
 import { theme } from "./theme";
 
+/**
+ * Component for editing a SQL cell.
+ *
+ * Two refs are required for the working of this SQL cell which uses codemirror.
+ * The `editorRef` is required to hold the reference to the container inside which the codemirror will be rendered.
+ * The second ref `viewRef` is used to store the codemirror's EditorView.
+ * This is done so that it won't be rendered each time there is a change in the dependencies.
+ * If `viewRef` is not used, multiple views will become visible in a single SQL cell editor component with some time.
+ *
+ * @param cellId - ID of the SQL cell to edit
+ */
 export function CellEditor({ cellId }: { cellId: string }) {
   const query = useCell(cellId);
   const queryClient = useQueryClient();
+  const viewRef = useRef<EditorView | null>(null);
   const editorRef = useRef<HTMLDivElement>(null);
   const updateCellMutation = useUpdateCell();
 
   useEffect(() => {
     let debouncedUpdate: ReturnType<typeof debounce> | undefined;
 
-    if (editorRef.current && query.data) {
+    if (editorRef.current && query.data && !viewRef.current) {
       const customKeymap: KeyBinding[] = NOTEBOOK_CELL_KEYBOARD_SHORTCUTS.map(
         (shortcut) => {
           const modifiers = shortcut.modifiers || [];
@@ -124,13 +136,18 @@ export function CellEditor({ cellId }: { cellId: string }) {
           EditorView.lineWrapping,
         ],
       });
-      new EditorView({
+      const view = new EditorView({
         parent: editorRef.current,
         state: state,
       });
+      viewRef.current = view;
     }
 
     return () => {
+      if (viewRef.current) {
+        viewRef.current.destroy();
+        viewRef.current = null;
+      }
       debouncedUpdate?.cancel();
     };
   }, [cellId, query.isPending]);

--- a/frontend/src/components/Notebook/CellEditor/theme.tsx
+++ b/frontend/src/components/Notebook/CellEditor/theme.tsx
@@ -25,7 +25,7 @@ const typeColor = getCSSVariable("--color-grey-700");
 const operatorColor = getCSSVariable("--color-grey-600");
 const commentColor = getCSSVariable("--color-grey-500");
 const stringColor = getCSSVariable("--color-green-600");
-const invalidColor = getCSSVariable("--color-red");
+const invalidColor = getCSSVariable("--color-red-500");
 
 const editorTheme = EditorView.theme(
   {

--- a/frontend/src/components/Notebook/CellOutput/CellOutput.tsx
+++ b/frontend/src/components/Notebook/CellOutput/CellOutput.tsx
@@ -1,7 +1,11 @@
-import { CellOutputState } from "src/components/Notebook/Cell";
-import { useStore } from "src/store";
-import { DataTable, ColumnConfig, Box } from "src/components/design-system";
-import CellOutputStles from "src/components/Notebook/CellOutput/CellOutput.module.css";
+import { useCellExecutionResult } from "src/api/cell";
+import {
+  DataTable,
+  ColumnConfig,
+  Flex,
+  BannerSlim,
+} from "src/components/design-system";
+import CellOutputStyles from "src/components/Notebook/CellOutput/CellOutput.module.css";
 import CellStyles from "src/css/cell.module.css";
 import { TableType } from "src/components/design-system/DataTable";
 
@@ -10,39 +14,52 @@ interface CellOutputProps {
 }
 
 export function CellOutput({ cellId }: CellOutputProps) {
-  const output = useStore((state) => state.cell.outputs[cellId]);
-  const outputState = useStore((state) => state.cell.outputStates[cellId]);
+  const { data: result } = useCellExecutionResult(cellId);
+
+  if (!result) return null;
+
+  if (result.status === "error") {
+    return (
+      <Flex
+        alignItems="center"
+        justifyContent="center"
+        paddingX="lg"
+        paddingY="lg"
+      >
+        <BannerSlim type="error" message={result.error.message} />
+      </Flex>
+    );
+  }
+
+  const { data } = result;
+  if (!data) return null;
 
   const columns: ColumnConfig<Record<string, unknown>>[] =
-    output?.columns?.map((column) => ({
-      key: column.column_name,
-      header: column.column_name,
+    data.columns?.map((col) => ({
+      key: col.column_name,
+      header: col.column_name,
       type: "accessor" as const,
-      accessor: column.column_name,
-      cell: (props) => props.getValue() as React.ReactNode,
-      dataType: column.data_type,
+      accessor: col.column_name,
+      dataType: col.data_type,
     })) ?? [];
 
-  const data = output?.data ?? [];
-
-  if (
-    outputState === CellOutputState.ABSENT ||
-    outputState === undefined ||
-    output === undefined
-  )
-    return null;
-
   return (
-    <Box paddingX="lg" paddingY="lg">
+    <Flex
+      alignItems="center"
+      justifyContent="center"
+      paddingX="lg"
+      paddingY="lg"
+    >
       <DataTable
         tableType={TableType.CLIENT_SIDE_PAGINATED}
         columns={columns}
-        data={data}
-        overallContainerStyle={`${CellStyles.outputContainerSql} ${CellOutputStles.outputContainer}`}
-        tableContainerStyle={`${CellOutputStles.tableContainer}`}
-        tableHeaderCellStyle={CellOutputStles.tableHeaderCell}
-        tableDataCellStyle={CellOutputStles.tableDataCell}
+        data={data.data ?? []}
+        emptyMessage="No rows match the query"
+        overallContainerStyle={`${CellStyles.outputContainerSql} ${CellOutputStyles.outputContainer}`}
+        tableContainerStyle={CellOutputStyles.tableContainer}
+        tableHeaderCellStyle={CellOutputStyles.tableHeaderCell}
+        tableDataCellStyle={CellOutputStyles.tableDataCell}
       />
-    </Box>
+    </Flex>
   );
 }

--- a/frontend/src/components/Notebook/CellToolbar/CellToolbar.module.css
+++ b/frontend/src/components/Notebook/CellToolbar/CellToolbar.module.css
@@ -6,13 +6,6 @@
   padding: 0 var(--space-2xs) 0 var(--space-2xs);
 }
 
-.rightSideContainer {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: var(--space-2xs);
-}
-
 .cellNameContainer {
   padding: 0 var(--space-xs) 0 var(--space-xs);
   color: var(--color-grey-700);

--- a/frontend/src/components/Notebook/CellToolbar/CellToolbar.tsx
+++ b/frontend/src/components/Notebook/CellToolbar/CellToolbar.tsx
@@ -4,11 +4,17 @@ import { IconButton } from "src/components/design-system/IconButton/IconButton";
 import { InlineEdit } from "src/components/design-system/InlineEdit";
 import { useConnections } from "src/api/connection";
 import { Select } from "src/components/design-system/Select";
-import { useUpdateCell, useCell } from "src/api/cell";
+import { useUpdateCell, useCell, useClearCellOutput } from "src/api/cell";
 import { useCallback, useEffect, useState } from "react";
 import { useHandleExecuteCell } from "src/components/Notebook/Cell";
+import { Flex, Kbd } from "src/components/design-system";
+import {
+  KEYBOARD_SHORTCUTS,
+  getShortcutDisplayString,
+} from "src/utils/keyboard_shortcuts";
 
 export function CellToolbar({ cellId }: { cellId: string }) {
+  const clearCellOutput = useClearCellOutput();
   const query = useConnections();
   const updateCellMutation = useUpdateCell();
   const getCellQuery = useCell(cellId);
@@ -71,9 +77,13 @@ export function CellToolbar({ cellId }: { cellId: string }) {
     [cellId, getCellQuery.data, updateCellMutation]
   );
 
-  const handleExecuteClick = useCallback(() => {
+  const handleExecute = useCallback(() => {
     handleExecuteCell(cellId);
   }, [cellId, handleExecuteCell]);
+
+  const handleClearOutput = useCallback(() => {
+    clearCellOutput(cellId);
+  }, [cellId, clearCellOutput]);
 
   const handleSelectChange = useCallback(
     (v: string) => handleValueChange(v || null),
@@ -91,7 +101,7 @@ export function CellToolbar({ cellId }: { cellId: string }) {
           className={CellToolbarStyles["toolbar__inlineEdit"]}
         />
       </div>
-      <div className={CellToolbarStyles.rightSideContainer}>
+      <Flex direction="row" alignItems="center" gap="md">
         <Select
           value={initialValue?.value ?? ""}
           onValueChange={handleSelectChange}
@@ -114,14 +124,46 @@ export function CellToolbar({ cellId }: { cellId: string }) {
           </Select.Content>
         </Select>
         <Toolbar.Button asChild>
-          <IconButton
-            type="play"
-            backgroundColor="transparent"
-            iconColor="green"
-            onClick={handleExecuteClick}
-          />
+          <Flex gap="2xs">
+            <IconButton
+              type="clear"
+              backgroundColor="transparent"
+              iconColor="red"
+              onClick={handleClearOutput}
+              tooltip={{
+                content: (
+                  <Flex direction="row" alignItems="center" gap="md">
+                    <span>Clear cell output</span>
+                    <Kbd>
+                      {getShortcutDisplayString(
+                        KEYBOARD_SHORTCUTS.CLEAR_NOTEBOOK_CELL
+                      )}
+                    </Kbd>
+                  </Flex>
+                ),
+              }}
+            />
+            <IconButton
+              type="play"
+              backgroundColor="transparent"
+              iconColor="green"
+              onClick={handleExecute}
+              tooltip={{
+                content: (
+                  <Flex direction="row" alignItems="center" gap="md">
+                    <span>Execute cell</span>
+                    <Kbd>
+                      {getShortcutDisplayString(
+                        KEYBOARD_SHORTCUTS.EXECUTE_NOTEBOOK_CELL
+                      )}
+                    </Kbd>
+                  </Flex>
+                ),
+              }}
+            />
+          </Flex>
         </Toolbar.Button>
-      </div>
+      </Flex>
     </Toolbar>
   );
 }

--- a/frontend/src/components/Notebook/ChartCell/CellEditor/CellEditor.tsx
+++ b/frontend/src/components/Notebook/ChartCell/CellEditor/CellEditor.tsx
@@ -10,7 +10,7 @@ import {
   useFormOptions,
 } from "src/components/Notebook/ChartCell/CellEditor/hooks";
 import { Form } from "src/components/design-system";
-import { ChartContent, getChartType } from "../../Cell/dto";
+import { getChartType } from "../../Cell/dto";
 import {
   getDefaultValuesForChart,
   extractChartFormData,
@@ -22,7 +22,7 @@ import { LineChartAccordion } from "./LineChartAccordion";
 import { PieChartFields } from "./PieChartFields";
 import { ChartRunButton } from "./ChartRunButton";
 import { ChartType } from "src/components/Chart";
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useState } from "react";
 
 /**
  * Component for editing a chart cell.
@@ -35,33 +35,28 @@ import { useCallback, useState, useEffect } from "react";
  */
 export function CellEditor({ cellId }: { cellId: string }) {
   const cellQuery = useCell(cellId);
-  const [initialChartContent, setInitialChartContent] =
-    useState<ChartContent | null>(null);
+  const initialChartContent = cellQuery.data
+    ? getChartContent(cellQuery.data)
+    : null;
   const { setSourceCellId, sourceCellId } = useSourceCellExecution(
     cellId,
     initialChartContent
   );
   const updateCellMutation = useUpdateCell();
   const formOptions = useFormOptions(sourceCellId);
-  const [chartType, setChartType] = useState<ChartType | null>(null);
+  const chartTypeFromContent = getChartType(initialChartContent);
+  const [chartTypeOverride, setChartTypeOverride] = useState<ChartType | null>(null);
+  const chartType = chartTypeOverride ?? chartTypeFromContent;
   const [accordionValues, setAccordionValues] = useState<string[]>([]);
   const defaultValues = getDefaultValuesForChart(
     chartType,
     initialChartContent
   );
 
-  useEffect(() => {
-    const newInitialChartContent = cellQuery.data
-      ? getChartContent(cellQuery.data)
-      : null;
-    setInitialChartContent(newInitialChartContent);
-    const newChartType = getChartType(newInitialChartContent);
-    setChartType(newChartType);
-  }, [cellQuery.data]);
-
   const handleSubmit = useCallback(
     (formData: FormData) => {
       if (!cellQuery.data) throw Error("Cell query data is empty");
+      if (!chartType) throw Error("Cell chart type is empty");
       const content = extractChartFormData(chartType, formData);
       const cellDto: CellDto = {
         ...cellQuery.data,
@@ -77,7 +72,7 @@ export function CellEditor({ cellId }: { cellId: string }) {
       if (fieldName === "cell_id") {
         setSourceCellId(value);
       } else if (fieldName === "chart_type") {
-        setChartType(ChartType[value as keyof typeof ChartType] ?? null);
+        setChartTypeOverride(ChartType[value as keyof typeof ChartType] ?? null);
       }
     },
     [setSourceCellId]

--- a/frontend/src/components/Notebook/ChartCell/CellEditor/ChartRunButton.tsx
+++ b/frontend/src/components/Notebook/ChartCell/CellEditor/ChartRunButton.tsx
@@ -30,7 +30,13 @@ export function ChartRunButton({
     const serialized = serializeChartContent(content);
     handleExecuteCellPreview(cellId, serialized, CellType.CHART);
     setChartContent(cellId, content);
-  }, [cellId, chartType, form.state.values, handleExecuteCellPreview, setChartContent]);
+  }, [
+    cellId,
+    chartType,
+    form.state.values,
+    handleExecuteCellPreview,
+    setChartContent,
+  ]);
 
   return (
     <Button

--- a/frontend/src/components/Notebook/ChartCell/CellEditor/hooks.tsx
+++ b/frontend/src/components/Notebook/ChartCell/CellEditor/hooks.tsx
@@ -3,50 +3,38 @@ import { useHandleExecuteCell } from "src/components/Notebook/Cell";
 import { useStore } from "src/store";
 import type { ChartContent } from "src/components/Notebook/Cell/dto";
 import { useNotebook } from "src/api/notebook/queries";
-import { CellOutputState, CellType } from "src/components/Notebook/Cell/dto";
+import { useCellExecutionResult } from "src/api/cell";
+import { CellType } from "src/components/Notebook/Cell/dto";
 import { ChartType } from "src/components/Chart";
 import { Icon, Flex, Text } from "src/components/design-system";
 import { AggregateFunction } from "src/components/Notebook/dto";
 import { getIconForDataType } from "src/utils/column_utils";
 
 export function useSourceCellExecution(
-  cellId: string,
+  _cellId: string,
   chartContent: ChartContent | null
 ) {
   const handleExecuteCell = useHandleExecuteCell();
   const [sourceCellId, setSourceCellId] = useState<string | null>(
     chartContent?.cell_id || null
   );
-  const setOutputState = useStore((state) => state.cell.setOutputState);
 
-  const onSuccessCallback = () => {
-    setOutputState(cellId, CellOutputState.PRESENT);
-  };
-  const onErrorCallback = () => {
-    setOutputState(cellId, CellOutputState.ERROR);
-  };
   const executeSourceCell = () => {
     if (sourceCellId) {
-      setOutputState(cellId, CellOutputState.EXECUTING);
-      handleExecuteCell(
-        sourceCellId,
-        false,
-        onSuccessCallback,
-        onErrorCallback
-      );
+      handleExecuteCell(sourceCellId);
     }
   };
 
   useEffect(() => {
     if (chartContent?.cell_id) {
-      handleExecuteCell(chartContent?.cell_id, false);
+      handleExecuteCell(chartContent?.cell_id);
       setSourceCellId(chartContent?.cell_id);
     }
   }, [chartContent?.cell_id]);
 
   useEffect(() => {
     if (sourceCellId) {
-      handleExecuteCell(sourceCellId, false);
+      handleExecuteCell(sourceCellId);
     }
   }, [sourceCellId]);
 
@@ -60,9 +48,11 @@ export function useSourceCellExecution(
 export function useFormOptions(sourceCellId: string | null) {
   const activeNotebookId = useStore((state) => state.canvas.activeNotebookId);
   const notebookQuery = useNotebook(activeNotebookId);
-  const sourceCellOutput = useStore((state) =>
-    sourceCellId ? state.cell.outputs[sourceCellId] : null
-  );
+  const { data: sourceCellOutput } = useCellExecutionResult(sourceCellId ?? "");
+  const columns =
+    sourceCellOutput?.status === "success"
+      ? sourceCellOutput.data.columns
+      : null;
 
   const cellOptions = useMemo(
     () =>
@@ -95,8 +85,8 @@ export function useFormOptions(sourceCellId: string | null) {
 
   const xAxisColumnOptions = useMemo(
     () =>
-      sourceCellOutput?.columns && sourceCellOutput.columns.length > 0
-        ? sourceCellOutput.columns.map((column) => ({
+      columns && columns.length > 0
+        ? columns.map((column) => ({
             value: column.column_name,
             label: (
               <Flex direction="row" gap="2xs" alignItems="center">
@@ -112,13 +102,13 @@ export function useFormOptions(sourceCellId: string | null) {
             textValue: column.column_name,
           }))
         : [],
-    [sourceCellOutput?.columns]
+    [columns]
   );
 
   const yAxisColumnOptions = useMemo(
     () =>
-      sourceCellOutput?.columns && sourceCellOutput.columns.length > 0
-        ? sourceCellOutput.columns.map((column) => ({
+      columns && columns.length > 0
+        ? columns.map((column) => ({
             value: column.column_name,
             label: (
               <Flex direction="row" gap="2xs" alignItems="center">
@@ -134,7 +124,7 @@ export function useFormOptions(sourceCellId: string | null) {
             textValue: column.column_name,
           }))
         : [],
-    [sourceCellOutput?.columns]
+    [columns]
   );
 
   return {

--- a/frontend/src/components/Notebook/ChartCell/CellEditor/utils.tsx
+++ b/frontend/src/components/Notebook/ChartCell/CellEditor/utils.tsx
@@ -29,42 +29,53 @@ export const VISIBILITY_OPTIONS = [
   { value: "HIDE", label: "Hide" },
 ];
 
+function getBarLineDefaults(chartType: ChartType, c: Record<string, unknown> | null) {
+  return {
+    cell_id: c?.cell_id,
+    chart_type: c?.chart_type ?? chartType,
+    x_axis: c?.x_axis ?? "",
+    x_axis_title: c?.x_axis_title ?? "",
+    y_axis: c?.y_axis ?? "",
+    y_axis_aggregate_function: c?.y_axis_aggregate_function,
+    y_axis_sort_order: c?.y_axis_sort_order ?? "NONE",
+    y_axis_title: c?.y_axis_title ?? "",
+    orientation: c?.orientation ?? "VERTICAL",
+    x_axis_tick_show: c?.x_axis_tick_show ?? "SHOW",
+    y_axis_tick_show: c?.y_axis_tick_show ?? "SHOW",
+    axis_minor_tick_show: c?.axis_minor_tick_show ?? "SHOW",
+    ...(chartType === ChartType.LINE && { show_dots: c?.show_dots ?? "SHOW" }),
+  };
+}
+
+function getPieDefaults(c: Record<string, unknown> | null) {
+  return {
+    cell_id: c?.cell_id,
+    chart_type: c?.chart_type ?? ChartType.PIE,
+    category: c?.category ?? "",
+    value: c?.value ?? "",
+    aggregate_function: c?.aggregate_function,
+  };
+}
+
 export function getDefaultValuesForChart(
   chartType: ChartType | null,
   chartContent: ChartContent | null
 ): Record<string, unknown> {
-  if (!chartContent) return {};
-
-  const c = chartContent as Record<string, unknown>;
-  const common = { cell_id: c.cell_id, chart_type: c.chart_type };
+  const c = chartContent as Record<string, unknown> | null;
 
   if (chartType === ChartType.BAR || chartType === ChartType.LINE) {
-    return {
-      ...common,
-      x_axis: c.x_axis,
-      x_axis_title: c.x_axis_title ?? "",
-      y_axis: c.y_axis,
-      y_axis_aggregate_function: c.y_axis_aggregate_function,
-      y_axis_sort_order: c.y_axis_sort_order ?? "NONE",
-      y_axis_title: c.y_axis_title ?? "",
-      orientation: c.orientation ?? "VERTICAL",
-      x_axis_tick_show: c.x_axis_tick_show ?? "SHOW",
-      y_axis_tick_show: c.y_axis_tick_show ?? "SHOW",
-      axis_minor_tick_show: c.axis_minor_tick_show ?? "SHOW",
-      ...(chartType === ChartType.LINE && { show_dots: c.show_dots ?? "SHOW" }),
-    };
+    return getBarLineDefaults(chartType, c);
   }
 
   if (chartType === ChartType.PIE) {
-    return {
-      ...common,
-      category: c.category,
-      value: c.value,
-      aggregate_function: c.aggregate_function,
-    };
+    return getPieDefaults(c);
   }
 
-  return common;
+  if (c) {
+    return { cell_id: c.cell_id, chart_type: c.chart_type };
+  }
+
+  return {};
 }
 
 export function extractBarChartFormData(formData: FormData): BarChartContent {
@@ -119,7 +130,7 @@ export function extractPieChartFormData(formData: FormData): PieChartContent {
 }
 
 export function extractChartFormData(
-  chartType: ChartType | null,
+  chartType: ChartType,
   formData: FormData
 ): BarChartContent | LineChartContent | PieChartContent {
   switch (chartType) {

--- a/frontend/src/components/Notebook/ChartCell/CellOutput/CellOutput.tsx
+++ b/frontend/src/components/Notebook/ChartCell/CellOutput/CellOutput.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { CellOutputState } from "src/components/Notebook/Cell";
+import { useCell, useCellExecutionResult } from "src/api/cell";
 import { useStore } from "src/store";
 import styles from "src/components/Notebook/ChartCell/CellOutput/CellOutput.module.css";
 import { BarChart, ChartType, LineChart, PieChart } from "src/components/Chart";
@@ -10,41 +10,95 @@ import {
   LineChartContent,
   PieChartContent,
 } from "../../Cell/dto";
+import {
+  BannerSlim,
+  Flex,
+  Heading,
+  Icon,
+  Text,
+} from "src/components/design-system";
 
 interface ChartCellOutputProps {
   cellId: string;
 }
 
 export function CellOutput({ cellId }: ChartCellOutputProps) {
-  const output = useStore((state) => state.cell.outputs[cellId]);
-  const outputState = useStore((state) => state.cell.outputStates[cellId]);
+  const { data: output } = useCellExecutionResult(cellId);
   const chartContent = useStore((state) => state.cell.chartContents[cellId]);
   const chartType = getChartType(chartContent);
+  const cellQuery = useCell(chartContent?.cell_id ?? "");
 
+  const executionData = output?.status === "success" ? output.data : null;
   const pieDimensions = useMemo(
-    () => output?.columns?.map((column) => column.column_name) ?? [],
-    [output?.columns]
+    () =>
+      executionData?.columns?.map(
+        (col: { column_name: string }) => col.column_name
+      ) ?? [],
+    [executionData?.columns]
   );
 
   function render() {
-    if (
-      outputState === undefined ||
-      outputState === CellOutputState.ABSENT ||
-      output === null ||
-      output === undefined ||
-      chartContent === null ||
-      output.data === null ||
-      output.data === undefined
-    ) {
-      return null;
+    if (output && output.status === "error") {
+      const message = `Check errors in ${cellQuery.data?.name}: ${output.error.message}. `;
+      return (
+        <Flex
+          alignItems="center"
+          justifyContent="center"
+          paddingX="lg"
+          paddingY="lg"
+          height="100%"
+        >
+          <BannerSlim type="error" message={message} />
+        </Flex>
+      );
     }
+
+    if (
+      output == null ||
+      chartContent == null ||
+      output.status !== "success" ||
+      executionData == null
+    ) {
+      return (
+        <Flex
+          as="section"
+          direction="column"
+          gap="md"
+          alignItems="center"
+          alignSelf="center"
+          paddingY="lg"
+          paddingX="lg"
+        >
+          <Icon
+            type="bar_chart"
+            color="lightgrey"
+            size="2xl"
+            interactive={false}
+          />
+          <Flex
+            direction="column"
+            gap="xs"
+            alignItems="center"
+            sx={{ textAlign: "center" }}
+          >
+            <Heading accessbilityLevel={2} textColor="default">
+              No chart rendered
+            </Heading>
+            <Text as="p" color="subtle">
+              Press on the run button to render the chart
+            </Text>
+          </Flex>
+        </Flex>
+      );
+    }
+    const chartData = executionData.data ?? [];
     if (chartType === ChartType.BAR) {
       const barChartContent = chartContent as BarChartContent;
       return (
         <BarChart
           xAxis={barChartContent.x_axis}
           yAxis={barChartContent.y_axis}
-          data={output.data}
+          data={chartData}
           xAxisTitle={barChartContent.x_axis_title}
           yAxisTitle={barChartContent.y_axis_title}
           xAxisTickShow={barChartContent.x_axis_tick_show}
@@ -58,7 +112,7 @@ export function CellOutput({ cellId }: ChartCellOutputProps) {
         <LineChart
           xAxis={lineChartContent.x_axis}
           yAxis={lineChartContent.y_axis}
-          data={output.data}
+          data={chartData}
           xAxisTitle={lineChartContent.x_axis_title}
           yAxisTitle={lineChartContent.y_axis_title}
           showDots={lineChartContent.show_dots !== "HIDE"}
@@ -74,7 +128,7 @@ export function CellOutput({ cellId }: ChartCellOutputProps) {
           category={pieChartContent.category}
           value={pieChartContent.value}
           dimensions={pieDimensions}
-          data={output.data}
+          data={chartData}
         />
       );
     }

--- a/frontend/src/components/Notebook/ChartCell/ChartCellToolbar/ChartCellToolbar.tsx
+++ b/frontend/src/components/Notebook/ChartCell/ChartCellToolbar/ChartCellToolbar.tsx
@@ -4,39 +4,11 @@ import * as Toolbar from "@radix-ui/react-toolbar";
 import { IconButton } from "src/components/design-system/IconButton/IconButton";
 import { InlineEdit } from "src/components/design-system/InlineEdit";
 import { useCell, useExecuteCell, useUpdateCell } from "src/api/cell";
-import { CellOutputState, ExecutionState } from "src/components/Notebook/Cell";
-import { useStore } from "src/store";
 import styles from "./ChartCellToolbar.module.css";
 
 export function ChartCellToolbar({ cellId }: { cellId: string }) {
-  const executeCellMutation = useExecuteCell();
   const updateCellMutation = useUpdateCell();
   const getCellQuery = useCell(cellId);
-  const setOutput = useStore((state) => state.cell.setOutput);
-  const setExecutionState = useStore((state) => state.cell.setExecutionState);
-  const setOutputState = useStore((state) => state.cell.setOutputState);
-
-  const handleExecute = useCallback(() => {
-    setExecutionState(cellId, ExecutionState.RUNNING);
-    executeCellMutation.mutate(cellId, {
-      onSuccess: (data) => {
-        setOutput(cellId, data);
-        setExecutionState(cellId, ExecutionState.COMPLETED);
-        if (data != null) {
-          setOutputState(cellId, CellOutputState.PRESENT);
-        }
-      },
-      onError: () => {
-        setExecutionState(cellId, ExecutionState.FAILED);
-      },
-    });
-  }, [
-    cellId,
-    executeCellMutation,
-    setExecutionState,
-    setOutput,
-    setOutputState,
-  ]);
 
   const handleSave = useCallback(
     (name: string) => {
@@ -62,14 +34,6 @@ export function ChartCellToolbar({ cellId }: { cellId: string }) {
           className={styles["toolbar__inlineEdit"]}
         />
       </div>
-      <Toolbar.Button asChild>
-        <IconButton
-          type="play"
-          backgroundColor="transparent"
-          iconColor="green"
-          onClick={handleExecute}
-        />
-      </Toolbar.Button>
     </Toolbar.Root>
   );
 }

--- a/frontend/src/components/Notebook/Notebook.tsx
+++ b/frontend/src/components/Notebook/Notebook.tsx
@@ -9,7 +9,12 @@ import { useHandleExecuteCell } from "src/components/Notebook/Cell";
 import { useKeyboardShortcut } from "src/utils/keyboard_shortcuts/hooks";
 import { Flex } from "src/components/design-system/Flex/Flex";
 import { useCallback, useRef, useMemo } from "react";
-import { useCreateCell, useDeleteCell, useReorderCell } from "src/api/cell";
+import {
+  useCreateCell,
+  useDeleteCell,
+  useReorderCell,
+  useClearCellOutput,
+} from "src/api/cell";
 import { useParams } from "react-router";
 
 export function Notebook() {
@@ -26,10 +31,17 @@ export function Notebook() {
   );
   const reorderCellMutation = useReorderCell(canvasId || undefined);
 
+  const clearCellOutput = useClearCellOutput();
+
   const handleExecute = useCallback(() => {
     const activeCellId = useStore.getState().notebook.activeCellId;
     handleExecuteCell(activeCellId);
   }, [handleExecuteCell]);
+
+  const handleClearOutput = useCallback(() => {
+    const activeCellId = useStore.getState().notebook.activeCellId;
+    if (activeCellId) clearCellOutput(activeCellId);
+  }, [clearCellOutput]);
 
   const handleReorderCell = (
     movementType: "UP" | "DOWN" | "TOP" | "BOTTOM"
@@ -71,6 +83,12 @@ export function Notebook() {
   );
 
   useKeyboardShortcut(
+    handleClearOutput,
+    KEYBOARD_SHORTCUTS.CLEAR_NOTEBOOK_CELL,
+    notebookRef
+  );
+
+  useKeyboardShortcut(
     () => handleReorderCell("UP"),
     KEYBOARD_SHORTCUTS.MOVE_CELL_UP,
     notebookRef
@@ -92,11 +110,6 @@ export function Notebook() {
     () => handleReorderCell("BOTTOM"),
     KEYBOARD_SHORTCUTS.MOVE_CELL_BOTTOM,
     notebookRef
-  );
-
-  useKeyboardShortcut(
-    () => handleCreateCell(CellType.MARKDOWN),
-    KEYBOARD_SHORTCUTS.ADD_MARKDOWN_CELL
   );
 
   useKeyboardShortcut(

--- a/frontend/src/components/Notebook/NotebookToolbar/NotebookToolbar.tsx
+++ b/frontend/src/components/Notebook/NotebookToolbar/NotebookToolbar.tsx
@@ -4,6 +4,10 @@ import { Toolbar } from "src/components/design-system/Toolbar";
 import { DropdownMenu } from "src/components/design-system/DropdownMenu";
 import { Kbd } from "src/components/design-system/Kbd";
 import { CellType } from "src/components/Notebook/Cell";
+import {
+  KEYBOARD_SHORTCUTS,
+  getShortcutDisplayString,
+} from "src/utils/keyboard_shortcuts";
 import { useCreateCell, useDeleteCell, useReorderCell } from "src/api/cell";
 import { Icon } from "src/components/design-system/Icon";
 import { useStore } from "src/store";
@@ -44,21 +48,18 @@ export function NotebookToolbar() {
     }
   }, [deleteCellMutation]);
 
-  const handleReorderCell = useCallback((
-    movementType: "UP" | "DOWN" | "TOP" | "BOTTOM"
-  ) => {
-    const activeCellId = useStore.getState().notebook.activeCellId;
-    if (activeCellId) {
-      reorderCellMutation.mutate({ cellId: activeCellId, movementType });
-    }
-  }, [reorderCellMutation]);
+  const handleReorderCell = useCallback(
+    (movementType: "UP" | "DOWN" | "TOP" | "BOTTOM") => {
+      const activeCellId = useStore.getState().notebook.activeCellId;
+      if (activeCellId) {
+        reorderCellMutation.mutate({ cellId: activeCellId, movementType });
+      }
+    },
+    [reorderCellMutation]
+  );
 
   const sxTransform = useMemo(() => ({ transform: "translateX(50%)" }), []);
 
-  const handleCreateMarkdown = useCallback(
-    () => handleCreateNewCell(CellType.MARKDOWN),
-    [handleCreateNewCell]
-  );
   const handleCreateSql = useCallback(
     () => handleCreateNewCell(CellType.SQL),
     [handleCreateNewCell]
@@ -85,13 +86,7 @@ export function NotebookToolbar() {
   );
 
   return (
-    <Flex
-      position="fixed"
-      bottom={10}
-      right="50%"
-      sx={sxTransform}
-      zIndex="10"
-    >
+    <Flex position="fixed" bottom={10} right="50%" sx={sxTransform} zIndex="10">
       <Toolbar className={styles.toolbar} aria-label="Notebook actions">
         <DropdownMenu>
           <DropdownMenu.Trigger>
@@ -100,20 +95,17 @@ export function NotebookToolbar() {
             </Toolbar.Button>
           </DropdownMenu.Trigger>
           <DropdownMenu.Content>
-            <DropdownMenu.Item
-              onClick={handleCreateMarkdown}
-            >
-              Markdown Cell <Kbd>⌘ M</Kbd>
+            <DropdownMenu.Item onClick={handleCreateSql}>
+              SQL Cell{" "}
+              <Kbd>
+                {getShortcutDisplayString(KEYBOARD_SHORTCUTS.ADD_SQL_CELL)}
+              </Kbd>
             </DropdownMenu.Item>
-            <DropdownMenu.Item
-              onClick={handleCreateSql}
-            >
-              SQL Cell <Kbd>⌘ Q</Kbd>
-            </DropdownMenu.Item>
-            <DropdownMenu.Item
-              onClick={handleCreateChart}
-            >
-              Chart Cell <Kbd>⌘ C</Kbd>
+            <DropdownMenu.Item onClick={handleCreateChart}>
+              Chart Cell{" "}
+              <Kbd>
+                {getShortcutDisplayString(KEYBOARD_SHORTCUTS.ADD_CHART_CELL)}
+              </Kbd>
             </DropdownMenu.Item>
           </DropdownMenu.Content>
         </DropdownMenu>
@@ -135,10 +127,16 @@ export function NotebookToolbar() {
           </DropdownMenu.Trigger>
           <DropdownMenu.Content>
             <DropdownMenu.Item onClick={handleReorderUp}>
-              Move Cell Up <Kbd>⌘ M</Kbd>
+              Move Cell Up{" "}
+              <Kbd>
+                {getShortcutDisplayString(KEYBOARD_SHORTCUTS.MOVE_CELL_UP)}
+              </Kbd>
             </DropdownMenu.Item>
             <DropdownMenu.Item onClick={handleReorderTop}>
-              Move Cell Top <Kbd>⇧ ⌘ M</Kbd>
+              Move Cell Top{" "}
+              <Kbd>
+                {getShortcutDisplayString(KEYBOARD_SHORTCUTS.MOVE_CELL_TOP)}
+              </Kbd>
             </DropdownMenu.Item>
           </DropdownMenu.Content>
         </DropdownMenu>
@@ -153,10 +151,16 @@ export function NotebookToolbar() {
           </DropdownMenu.Trigger>
           <DropdownMenu.Content>
             <DropdownMenu.Item onClick={handleReorderDown}>
-              Move Cell Down <Kbd>⌘ T</Kbd>
+              Move Cell Down{" "}
+              <Kbd>
+                {getShortcutDisplayString(KEYBOARD_SHORTCUTS.MOVE_CELL_DOWN)}
+              </Kbd>
             </DropdownMenu.Item>
             <DropdownMenu.Item onClick={handleReorderBottom}>
-              Move Cell Bottom <Kbd>⇧ ⌘ T</Kbd>
+              Move Cell Bottom{" "}
+              <Kbd>
+                {getShortcutDisplayString(KEYBOARD_SHORTCUTS.MOVE_CELL_BOTTOM)}
+              </Kbd>
             </DropdownMenu.Item>
           </DropdownMenu.Content>
         </DropdownMenu>

--- a/frontend/src/components/Settings/Settings.tsx
+++ b/frontend/src/components/Settings/Settings.tsx
@@ -6,28 +6,16 @@ import { Flex } from "src/components/design-system/Flex/Flex";
 import { Heading } from "src/components/design-system";
 
 export function Settings() {
-  const tabItems = useMemo<TabItem[]>(() => [
-    {
-      id: "connections",
-      label: "Connections",
-      content: <Connections />,
-    },
-    {
-      id: "permissions",
-      label: "Permissions",
-      content: <div>Permissions content goes here</div>,
-    },
-    {
-      id: "security",
-      label: "Security",
-      content: <div>Security content goes here</div>,
-    },
-    {
-      id: "alerts",
-      label: "Alerts & Reports",
-      content: <div>Alerts & Reports content goes here</div>,
-    },
-  ], []);
+  const tabItems = useMemo<TabItem[]>(
+    () => [
+      {
+        id: "connections",
+        label: "Connections",
+        content: <Connections />,
+      },
+    ],
+    []
+  );
 
   return (
     <Flex

--- a/frontend/src/components/SophoForm/SophoForm.module.css
+++ b/frontend/src/components/SophoForm/SophoForm.module.css
@@ -101,17 +101,17 @@
 }
 
 .formMessage {
-  color: var(--color-red-dark-2);
+  color: var(--color-red-700);
   font-size: var(--font-size-sm);
 }
 
 .formError {
-  color: var(--color-red-dark-2);
+  color: var(--color-red-700);
   font-size: var(--font-size-base);
   padding: 0.5rem;
   background-color: var(--error-background);
   border-radius: var(--border-radius-lg);
-  border: 1px solid var(--color-red-dark-2);
+  border: 1px solid var(--color-red-700);
 }
 
 .formButtonRow {

--- a/frontend/src/components/design-system/BannerSlim/BannerSlim.tsx
+++ b/frontend/src/components/design-system/BannerSlim/BannerSlim.tsx
@@ -23,7 +23,7 @@ export function BannerSlim({ type, message }: BannerSlimProps) {
       gap="xs"
     >
       <span className={styles.iconWrapper}>
-        <Icon type="triangle_alert" color="error"></Icon>
+        <Icon type="triangle_alert" color="default"></Icon>
       </span>
       <Text color="default" fontSize="sm">
         {message}

--- a/frontend/src/components/design-system/Box/Box.module.css
+++ b/frontend/src/components/design-system/Box/Box.module.css
@@ -6,7 +6,7 @@
 }
 
 .error {
-  background-color: var(--color-red-light-5);
+  background-color: var(--color-red-200);
 }
 
 .grey {

--- a/frontend/src/components/design-system/Button/Button.module.css
+++ b/frontend/src/components/design-system/Button/Button.module.css
@@ -59,15 +59,15 @@
 }
 
 .red {
-  background-color: var(--color-red);
+  background-color: var(--color-red-500);
 }
 
 .red:hover {
-  background-color: var(--color-red-dark-1);
+  background-color: var(--color-red-600);
 }
 
 .red:active {
-  background-color: var(--color-red-dark-2);
+  background-color: var(--color-red-700);
 }
 
 .lightgrey {

--- a/frontend/src/components/design-system/DataTable/DataTable.module.css
+++ b/frontend/src/components/design-system/DataTable/DataTable.module.css
@@ -111,6 +111,12 @@
   border-bottom: none;
 }
 
+.emptyStateCell {
+  padding: var(--space-xl);
+  text-align: center;
+  color: var(--color-grey-500);
+}
+
 .tableBody tc:last-child td {
   border-right: none;
 }

--- a/frontend/src/components/design-system/DataTable/DataTable.tsx
+++ b/frontend/src/components/design-system/DataTable/DataTable.tsx
@@ -11,6 +11,7 @@ import { TableBody } from "src/components/design-system/DataTable/components/Tab
 import { Input } from "src/components/design-system/Input";
 import { Flex } from "src/components/design-system/Flex";
 import styles from "src/components/design-system/DataTable/DataTable.module.css";
+import { Text } from "../Text";
 
 export function DataTable<T>({
   tableType = TableType.FULL,
@@ -31,7 +32,12 @@ export function DataTable<T>({
   enableColumnResizing = true,
   enableRowDragging = false,
   getRowId,
+  emptyMessage = "No data",
+  emptySearchMessage = "No results match your search",
 }: DataTableProps<T>) {
+  if (data === undefined || data === null || data.length === 0) {
+    return <Text color="subtle">{emptyMessage}</Text>;
+  }
   const { table, columnConfigMap, globalFilter } = useDataTable({
     tableType,
     columns,
@@ -43,6 +49,7 @@ export function DataTable<T>({
   });
 
   const rowDragging = useRowDragging(table);
+  const rows = table.getRowModel().rows;
   const [hoveredColumnId, setHoveredColumnId] = useState<string | null>(null);
   const isResizingColumn = Boolean(
     table.getState().columnSizingInfo?.isResizingColumn
@@ -64,7 +71,7 @@ export function DataTable<T>({
         <Input
           value={globalFilter}
           onChange={(e) => table.setGlobalFilter(String(e.target.value))}
-          placeholder="Search..."
+          placeholder="Search"
           leadingIcon="search"
         />
         {renderPaginationControl(
@@ -92,7 +99,11 @@ export function DataTable<T>({
             tableLastHeaderCellStyle={tableLastHeaderCellStyle}
           />
           <TableBody
-            rows={table.getRowModel().rows}
+            rows={rows}
+            emptySearchMessage={
+              rows.length === 0 ? emptySearchMessage : undefined
+            }
+            columnCount={table.getHeaderGroups()[0]?.headers.length || 1}
             columnConfigMap={columnConfigMap}
             hoveredColumnId={hoveredColumnId}
             tableDataCellStyle={tableDataCellStyle}

--- a/frontend/src/components/design-system/DataTable/components/TableBody.tsx
+++ b/frontend/src/components/design-system/DataTable/components/TableBody.tsx
@@ -12,6 +12,8 @@ type TableBodyProps<T> = {
   draggingRowId: string | null;
   onDragStart: (e: React.DragEvent<HTMLTableRowElement>, row: Row<T>) => void;
   onDragEnd: () => void;
+  emptySearchMessage?: string;
+  columnCount: number;
 };
 
 export function TableBody<T>({
@@ -23,10 +25,19 @@ export function TableBody<T>({
   draggingRowId,
   onDragStart,
   onDragEnd,
+  emptySearchMessage,
+  columnCount,
 }: TableBodyProps<T>) {
   return (
     <tbody className={styles.tableBody}>
-      {rows.map((row) => {
+      {emptySearchMessage ? (
+        <tr>
+          <td colSpan={columnCount} className={styles.emptyStateCell}>
+            {emptySearchMessage}
+          </td>
+        </tr>
+      ) : (
+        rows.map((row) => {
         const isDragging = draggingRowId === row.id;
         return (
           <TableRow
@@ -38,10 +49,11 @@ export function TableBody<T>({
             isDragging={isDragging}
             enableRowDragging={enableRowDragging}
             onDragStart={(e) => onDragStart(e, row)}
-            onDragEnd={onDragEnd}
-          />
+          onDragEnd={onDragEnd}
+        />
         );
-      })}
+      })
+      )}
     </tbody>
   );
 }

--- a/frontend/src/components/design-system/DataTable/types.ts
+++ b/frontend/src/components/design-system/DataTable/types.ts
@@ -51,5 +51,7 @@ export type DataTableProps<T> = {
   enableColumnResizing?: boolean;
   enableRowDragging?: boolean;
   getRowId?: (row: T) => string;
+  emptyMessage?: string;
+  emptySearchMessage?: string;
 };
 

--- a/frontend/src/components/design-system/Form/Form.module.css
+++ b/frontend/src/components/design-system/Form/Form.module.css
@@ -77,7 +77,7 @@
 }
 
 .formMessage {
-  color: var(--color-red-dark-2);
+  color: var(--color-red-700);
   font-size: var(--font-size-xs);
 }
 

--- a/frontend/src/components/design-system/Heading/Heading.tsx
+++ b/frontend/src/components/design-system/Heading/Heading.tsx
@@ -67,7 +67,7 @@ function getTextColor(color: TextColor | undefined): string | undefined {
     white: getCSSVariable("--color-background"),
     subtle: getCSSVariable("--color-grey-500"),
     disabled: getCSSVariable("--color-grey-500"),
-    error: getCSSVariable("--color-red"),
+    error: getCSSVariable("--color-red-500"),
     success: getCSSVariable("--color-green-500"),
     warning: getCSSVariable("--color-grey-700"),
     black: getCSSVariable("--color-grey-800"),

--- a/frontend/src/components/design-system/Icon/Icon.module.css
+++ b/frontend/src/components/design-system/Icon/Icon.module.css
@@ -7,11 +7,11 @@
   color: var(--color-primary-500);
 }
 
-.accent:hover {
+.interactive.accent:hover {
   color: var(--color-primary-600);
 }
 
-.accent:active {
+.interactive.accent:active {
   color: var(--color-primary-400);
 }
 
@@ -19,11 +19,11 @@
   color: var(--color-background);
 }
 
-.white:hover {
+.interactive.white:hover {
   color: var(--color-grey-200);
 }
 
-.white:active {
+.interactive.white:active {
   color: var(--color-grey-100);
 }
 
@@ -31,12 +31,24 @@
   color: var(--color-grey-500);
 }
 
-.grey:hover {
+.interactive.grey:hover {
   color: var(--color-grey-600);
 }
 
-.grey:active {
+.interactive.grey:active {
   color: var(--color-grey-400);
+}
+
+.lightgrey {
+  color: var(--color-grey-300);
+}
+
+.interactive.lightgrey:hover {
+  color: var(--color-grey-400);
+}
+
+.interactive.lightgrey:active {
+  color: var(--color-grey-200);
 }
 
 .green {
@@ -44,11 +56,11 @@
   stroke-width: 0;
 }
 
-.green:hover {
+.interactive.green:hover {
   fill: var(--color-green-600);
 }
 
-.green:active {
+.interactive.green:active {
   color: var(--color-green-400);
 }
 
@@ -56,24 +68,24 @@
   color: var(--color-grey-800);
 }
 
-.black:hover {
+.interactive.black:hover {
   color: var(--color-text);
 }
 
-.black:active {
+.interactive.black:active {
   color: var(--color-grey-900);
 }
 
 .red {
-  color: var(--color-red);
+  color: var(--color-red-500);
 }
 
-.red:hover {
-  color: var(--color-red-dark-1);
+.interactive.red:hover {
+  color: var(--color-red-600);
 }
 
-.red:active {
-  color: var(--color-red-light-1);
+.interactive.red:active {
+  color: var(--color-red-400);
 }
 
 .filled {

--- a/frontend/src/components/design-system/Icon/Icon.tsx
+++ b/frontend/src/components/design-system/Icon/Icon.tsx
@@ -51,6 +51,7 @@ import {
   BarChart,
   Table,
   LayoutDashboard,
+  Plug,
 } from "lucide-react";
 
 const iconMap: Record<IconType, LucideIcon> = {
@@ -66,6 +67,7 @@ const iconMap: Record<IconType, LucideIcon> = {
   visibility_off: EyeOff,
   edit: Pencil,
   delete: Trash2,
+  clear: CircleX,
   play: Play,
   remove: Minus,
   arrow_up: ArrowUp,
@@ -99,12 +101,14 @@ const iconMap: Record<IconType, LucideIcon> = {
   bar_chart: BarChart,
   table: Table,
   layout_dashboard: LayoutDashboard,
+  plug: Plug,
 };
 
 const sizeMap: Record<IconSize, number> = {
   sm: 14,
   md: 20,
   lg: 24,
+  "2xl": 450,
 };
 
 type IconProps = {
@@ -112,6 +116,7 @@ type IconProps = {
   color: IconColor;
   strokeWidth?: number;
   size?: IconSize;
+  interactive?: boolean;
 };
 
 export function Icon({
@@ -119,6 +124,7 @@ export function Icon({
   color,
   strokeWidth = 2.25,
   size = "md",
+  interactive = true,
 }: IconProps) {
   const className = styles[color];
   const IconComponent = iconMap[type];
@@ -126,7 +132,7 @@ export function Icon({
   return (
     <IconComponent
       size={iconSize}
-      className={`${styles.icon} ${className}`}
+      className={`${styles.icon} ${className}${interactive ? ` ${styles.interactive}` : ""}`}
       strokeWidth={strokeWidth}
     />
   );

--- a/frontend/src/components/design-system/IconButton/IconButton.tsx
+++ b/frontend/src/components/design-system/IconButton/IconButton.tsx
@@ -13,7 +13,8 @@ type IconButtonProps = {
   iconColor: IconColor;
   iconSize?: IconSize;
   tooltip?: {
-    text: string;
+    text?: string;
+    content?: React.ReactNode;
     direction?: "top" | "right" | "bottom" | "left";
   };
   onClick: () => void;
@@ -45,7 +46,7 @@ export function IconButton({
   if (tooltip) {
     return (
       <ToolTip
-        messageElement={tooltip.text}
+        messageElement={tooltip.content ?? tooltip.text}
         tooltipSide={tooltip.direction || "top"}
       >
         {button}

--- a/frontend/src/components/design-system/InlineEdit/InlineEdit.tsx
+++ b/frontend/src/components/design-system/InlineEdit/InlineEdit.tsx
@@ -36,8 +36,11 @@ export function InlineEdit({
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(value);
 
+  const effectiveValue = (val: string) =>
+    (val?.trim() ?? "") !== "" ? val : (defaultValue ?? "");
+
   const handleAccept = () => {
-    onSave(editValue);
+    onSave(effectiveValue(editValue));
     setIsEditing(false);
   };
 
@@ -78,11 +81,6 @@ export function InlineEdit({
                 : undefined,
               styles["inlineEdit__input"],
             ])}
-            style={
-              {
-                // width: "500px",
-              }
-            }
           />
         </div>
         <Flex direction="row" gap="xs" className={styles.actions}>
@@ -109,8 +107,7 @@ export function InlineEdit({
     );
   }
 
-  const displayValue =
-    (value?.trim() ?? "") !== "" ? value : (defaultValue ?? "");
+  const displayValue = effectiveValue(value);
 
   return (
     <div

--- a/frontend/src/components/design-system/SearchBar/SearchBar.tsx
+++ b/frontend/src/components/design-system/SearchBar/SearchBar.tsx
@@ -2,6 +2,10 @@ import { Fragment, useState } from "react";
 import { Input } from "src/components/design-system/Input/Input";
 import { Kbd } from "src/components/design-system/Kbd";
 import { CommandMenu } from "src/components/design-system/CommandMenu/CommandMenu";
+import {
+  KEYBOARD_SHORTCUTS,
+  getShortcutDisplayString,
+} from "src/utils/keyboard_shortcuts";
 import styles from "./SearchBar.module.css";
 
 export function SearchBar() {
@@ -26,7 +30,7 @@ export function SearchBar() {
         type="text"
         placeholder="Search"
         leadingIcon="search"
-        laggingElement={<Kbd>⌘ K</Kbd>}
+        laggingElement={<Kbd>{getShortcutDisplayString(KEYBOARD_SHORTCUTS.OPEN_COMMAND_MENU)}</Kbd>}
         className={styles.container}
       />
       <CommandMenu

--- a/frontend/src/components/design-system/Text/Text.module.css
+++ b/frontend/src/components/design-system/Text/Text.module.css
@@ -15,7 +15,7 @@
 }
 
 .error {
-  color: var(--color-red);
+  color: var(--color-red-500);
 }
 
 .fontSize-xs {

--- a/frontend/src/components/design-system/datatypes.tsx
+++ b/frontend/src/components/design-system/datatypes.tsx
@@ -18,6 +18,7 @@ export type IconColor =
   | "warning"
   | "green"
   | "grey"
+  | "lightgrey"
   | "red"
   | "transparent";
 
@@ -34,6 +35,7 @@ export type IconType =
   | "visibility_off"
   | "edit"
   | "delete"
+  | "clear"
   | "play"
   | "remove"
   | "arrow_up"
@@ -67,9 +69,10 @@ export type IconType =
   | "layers"
   | "bar_chart"
   | "table"
-  | "layout_dashboard";
+  | "layout_dashboard"
+  | "plug";
 
-export type IconSize = "sm" | "md" | "lg";
+export type IconSize = "sm" | "md" | "lg" | "2xl";
 
 export type FlexValue = "grow" | "shrink" | "none" | NumberString;
 

--- a/frontend/src/css/index.css
+++ b/frontend/src/css/index.css
@@ -118,19 +118,15 @@ button {
   --color-green-200: hsl(84, 70%, 85%, 1);
   --color-green-100: hsl(84, 65%, 95%, 1);
 
-  --color-red-light-1: hsl(0, 80%, 70%, 1);
-  --color-red-light-2: hsl(0, 75%, 80%, 1);
-  --color-red-light-3: hsl(0, 70%, 85%, 1);
-  --color-red-light-4: hsl(0, 65%, 90%, 1);
-  --color-red-light-5: hsl(0, 100%, 94%, 1);
-  --color-red-light-6: hsl(0, 55%, 98%, 1);
-  --color-red: hsl(0, 84%, 60%, 1);
-  --color-red-dark-1: hsl(0, 72%, 50%, 1);
-  --color-red-dark-2: hsl(0, 75%, 40%, 1);
-  --color-red-dark-3: hsl(0, 78%, 30%, 1);
-  --color-red-dark-4: hsl(0, 80%, 20%, 1);
-  --color-red-dark-5: hsl(0, 85%, 12%, 1);
-  --color-red-dark-6: hsl(0, 90%, 5%, 1);
+  --color-red-100: hsl(0, 55%, 98%, 1);
+  --color-red-200: hsl(0, 65%, 94%, 1);
+  --color-red-300: hsl(0, 70%, 90%, 1);
+  --color-red-400: hsl(0, 75%, 85%, 1);
+  --color-red-500: hsl(0, 84%, 60%, 1);
+  --color-red-600: hsl(0, 72%, 50%, 1);
+  --color-red-700: hsl(0, 75%, 40%, 1);
+  --color-red-800: hsl(0, 78%, 30%, 1);
+  --color-red-900: hsl(0, 85%, 12%, 1);
 
   --color-blue-base: 217, 91%, 60%;
   --color-blue-900: hsla(217, 80%, 20%, 1);
@@ -291,7 +287,7 @@ button {
   --border-color-light: var(--color-grey-300);
   --border-color-dark: var(--color-grey-400);
   --border-color-focus: var(--color-primary-500);
-  --border-color-error: var(--color-red-dark-2);
+  --border-color-error: var(--color-red-700);
   --border-color-success: var(--color-green-500);
 
   /* Semantic Borders */

--- a/frontend/src/store/cellSlice.ts
+++ b/frontend/src/store/cellSlice.ts
@@ -1,74 +1,22 @@
 import { StateCreator } from "zustand";
-import type {
-  CellOutputState,
-  ChartContent,
-  ExecuteCellResponseDto,
-  ExecutionState,
-} from "src/components/Notebook/Cell/dto";
+import type { ChartContent } from "src/components/Notebook/Cell/dto";
 
 export type CellSlice = {
   cell: {
-    outputs: Record<string, ExecuteCellResponseDto>;
-    executionStates: Record<string, ExecutionState>;
-    outputStates: Record<string, CellOutputState>;
-    // Content that is being edited in the frontend. It may or may not be persisted in the backend.
-    chartContents: Record<string, ChartContent>;
-    setExecutionState: (cellId: string, executionState: ExecutionState) => void;
-    getExecutionState: (cellId: string) => ExecutionState | undefined;
-    setOutputState: (cellId: string, outputState: CellOutputState) => void;
-    getOutputState: (cellId: string) => CellOutputState | undefined;
-    setOutput: (cellId: string, output: ExecuteCellResponseDto) => void;
-    clearOutput: (cellId: string) => void;
-    clearAll: () => void;
-    getOutput: (cellId: string) => ExecuteCellResponseDto | undefined;
-    setChartContent: (cellId:string, chartContent: ChartContent) => void;
+    chartContents: Record<string, ChartContent | null>;
+    setChartContent: (cellId: string, chartContent: ChartContent | null) => void;
   };
 };
 
-export const createCellSlice: StateCreator<CellSlice> = (set, get) => ({
+export const createCellSlice: StateCreator<CellSlice> = (set) => ({
   cell: {
-    outputs: {},
-    executionStates: {},
-    outputStates: {},
     chartContents: {},
-    setExecutionState: (cellId, executionState) =>
+    setChartContent: (cellId, newChartContent) =>
       set((state) => ({
         cell: {
           ...state.cell,
-          executionStates: { ...state.cell.executionStates, [cellId]: executionState },
+          chartContents: { ...state.cell.chartContents, [cellId]: newChartContent },
         },
       })),
-    getExecutionState: (cellId) => get().cell.executionStates[cellId],
-    setOutputState: (cellId, outputState) =>
-      set((state) => ({
-        cell: {
-          ...state.cell,
-          outputStates: { ...state.cell.outputStates, [cellId]: outputState },
-        },
-      })),
-    getOutputState: (cellId) => get().cell.outputStates[cellId],
-    getOutput: (cellId) => get().cell.outputs[cellId],
-    setOutput: (cellId, output) =>
-      set((state) => ({
-        cell: {
-          ...state.cell,
-          outputs: { ...state.cell.outputs, [cellId]: output },
-        },
-      })),
-    clearOutput: (cellId) =>
-      set((state) => {
-        const rest = Object.fromEntries(
-          Object.entries(state.cell.outputs).filter(([k]) => k !== cellId)
-        );
-        return { cell: { ...state.cell, outputs: rest } };
-      }),
-    clearAll: () =>
-      set((state) => ({ cell: { ...state.cell, outputs: {} } })),
-    setChartContent: (cellId, newChartContent) => set((state) => ({
-      cell: {
-        ...state.cell,
-        chartContents: {...state.cell.chartContents, [cellId]: newChartContent},
-      },
-    })),
   },
 });

--- a/frontend/src/utils/api_client.tsx
+++ b/frontend/src/utils/api_client.tsx
@@ -1,3 +1,18 @@
+import { ApiError, ApiErrorBody } from "src/api/dto";
+
+async function handleErrorResponse(response: Response): Promise<never> {
+  let body: ApiErrorBody = {};
+  const contentType = response.headers.get("content-type");
+  if (contentType?.includes("application/json")) {
+    try {
+      body = (await response.json()) as ApiErrorBody;
+    } catch {
+      body = {};
+    }
+  }
+  throw new ApiError(response.status, body, body.message ?? body.message);
+}
+
 export const ApiService = {
   post: async <T = unknown,>({
     url,
@@ -19,7 +34,7 @@ export const ApiService = {
       credentials: credentials ? "include" : undefined,
     });
     if (!response.ok) {
-      throw response;
+      await handleErrorResponse(response);
     }
     if (onlyBody) {
       return response.json() as Promise<T>;
@@ -43,7 +58,7 @@ export const ApiService = {
       credentials: credentials ? "include" : undefined,
     });
     if (!response.ok) {
-      throw response;
+      await handleErrorResponse(response);
     }
     if (onlyBody) {
       return response.json() as Promise<T>;
@@ -70,7 +85,7 @@ export const ApiService = {
       credentials: credentials ? "include" : undefined,
     });
     if (!response.ok) {
-      throw response;
+      await handleErrorResponse(response);
     }
     if (onlyBody) {
       return response.json() as Promise<T>;
@@ -97,7 +112,7 @@ export const ApiService = {
       credentials: credentials ? "include" : undefined,
     });
     if (!response.ok) {
-      throw response;
+      await handleErrorResponse(response);
     }
     if (onlyBody) {
       return response.json() as Promise<T>;

--- a/frontend/src/utils/error_handler.tsx
+++ b/frontend/src/utils/error_handler.tsx
@@ -1,5 +1,6 @@
 import { Mutation, Query, QueryKey } from "@tanstack/react-query";
 import { authApi } from "src/api/auth_api";
+import { ApiError } from "src/api/dto";
 import { APP_ROUTES } from "src/constants/app_routes";
 
 let isRefreshing = false;
@@ -13,7 +14,7 @@ let failedQueue: {
 const refreshAndRetry = async (
   query?: Query<unknown, unknown, unknown, QueryKey>,
   mutation?: Mutation<unknown, unknown, unknown, unknown>,
-  variables?: unknown,
+  variables?: unknown
 ) => {
   if (isRefreshing) {
     failedQueue.push({ query, mutation, variables });
@@ -42,21 +43,23 @@ const errorHandler = (
   error: unknown,
   query?: Query<unknown, unknown, unknown, QueryKey>,
   mutation?: Mutation<unknown, unknown, unknown, unknown>,
-  variables?: unknown,
+  variables?: unknown
 ) => {
   const status = error instanceof Response ? error.status : undefined;
-  if (status === 401) {
-    if (query) {
-      refreshAndRetry(query);
-    } else if (mutation) {
-      refreshAndRetry(undefined, mutation, variables);
+  if (error instanceof ApiError) {
+    if (status === 401) {
+      if (query) {
+        refreshAndRetry(query);
+      } else if (mutation) {
+        refreshAndRetry(undefined, mutation, variables);
+      }
     }
   }
 };
 
 export const queryErrorHandler = (
   error: unknown,
-  query: Query<unknown, unknown, unknown, QueryKey>,
+  query: Query<unknown, unknown, unknown, QueryKey>
 ) => {
   errorHandler(error, query, undefined, undefined);
 };
@@ -65,7 +68,7 @@ export const mutationErrorHandler = (
   error: unknown,
   variables: unknown,
   _context: unknown,
-  mutation: Mutation<unknown, unknown, unknown, unknown>,
+  mutation: Mutation<unknown, unknown, unknown, unknown>
 ) => {
   errorHandler(error, undefined, mutation, variables);
 };

--- a/frontend/src/utils/keyboard_shortcuts/index.tsx
+++ b/frontend/src/utils/keyboard_shortcuts/index.tsx
@@ -1,5 +1,6 @@
 export {
   KEYBOARD_SHORTCUTS,
   NOTEBOOK_CELL_KEYBOARD_SHORTCUTS,
+  getShortcutDisplayString,
 } from "src/utils/keyboard_shortcuts/keyboard_shortcuts";
 export { useKeyboardShortcut } from "src/utils/keyboard_shortcuts/hooks";

--- a/frontend/src/utils/keyboard_shortcuts/keyboard_shortcuts.tsx
+++ b/frontend/src/utils/keyboard_shortcuts/keyboard_shortcuts.tsx
@@ -14,27 +14,27 @@ export const KEYBOARD_SHORTCUTS = {
     description: "Execute the notebook cell to generate results",
     preventDefault: true,
   },
+  CLEAR_NOTEBOOK_CELL: {
+    key: "Enter",
+    modifiers: ["meta", "shift"],
+    description: "Clears the notebook cell results",
+    preventDefault: true,
+  },
   OPEN_COMMAND_MENU: {
     key: "k",
     modifiers: ["meta"],
     description: "Open the command menu",
     preventDefault: true,
   },
-  ADD_MARKDOWN_CELL: {
-    key: "m",
-    modifiers: ["meta"],
-    description: "Add markdown cell",
-    preventDefault: true,
-  },
   ADD_SQL_CELL: {
-    key: "G",
-    modifiers: ["meta"],
+    key: "l",
+    modifiers: ["meta", "shift"],
     description: "Add SQL cell",
     preventDefault: true,
   },
   ADD_CHART_CELL: {
-    key: "c",
-    modifiers: ["meta"],
+    key: "p",
+    modifiers: ["meta", "shift"],
     description: "Add chart cell",
     preventDefault: true,
   },
@@ -72,6 +72,7 @@ export const KEYBOARD_SHORTCUTS = {
 
 export const NOTEBOOK_CELL_KEYBOARD_SHORTCUTS = [
   KEYBOARD_SHORTCUTS.EXECUTE_NOTEBOOK_CELL,
+  KEYBOARD_SHORTCUTS.CLEAR_NOTEBOOK_CELL,
 ];
 
 export function matchesAnyShortcut(
@@ -119,8 +120,17 @@ export function getShortcutDisplayString(shortcut: KeyboardShortcut): string {
     }
   });
 
-  const keyDisplay = shortcut.key === " " ? "Space" : shortcut.key;
-  return [...modifierSymbols, keyDisplay].join(isMac ? "" : "+");
+  const arrowKeySymbols: Record<string, string> = {
+    ArrowUp: "↑",
+    ArrowDown: "↓",
+    ArrowLeft: "←",
+    ArrowRight: "→",
+  };
+  const keyDisplay =
+    shortcut.key === " "
+      ? "Space"
+      : (arrowKeySymbols[shortcut.key] ?? shortcut.key);
+  return [...modifierSymbols, keyDisplay].join(isMac ? " " : "+");
 }
 
 export function handleKeyboardShortcut(


### PR DESCRIPTION
## Summary

Adds the ability to clear cell output from notebook and chart cells, along with empty state components for the Home page and backend error handling improvements.

## Changes

### Clear Cell Output
- **Clear button** in notebook and chart cell toolbars to remove execution results
- **Keyboard shortcut** `Cmd+Shift+Enter` (Mac) / `Ctrl+Shift+Enter` (Windows/Linux) to clear the focused cell output
- Client-side cache invalidation for cell execution results

### Home Empty States
- Introduced reusable `EmptyState` component with icon, heading, description, and CTA
- `CanvasesEmptyState` – when user has no canvases
- `ConnectionsEmptyState` – when user has no connections  
- `HomeEmptyState` – general empty state for home page

### Backend
- Improved SQL execution error handling with structured error codes (`syntax_error`, `missing_prerequisites`)
- Clearer "Choose a connection" message when cell has no connection assigned

### Other
- Refactored ChartCell toolbar (removed separate ChartCellToolbar component)
- Design system refinements: Icon, DataTable, Button, and related components
- Removed unused execute.svg asset

## Breaking Changes

None.

---

Refs: #78