### PR TITLE
feat(conversational-analytics): add slash commands and canvas generation

### DIFF
--- a/backend/src/ai/agent_utils.rs
+++ b/backend/src/ai/agent_utils.rs
@@ -17,6 +17,7 @@ pub enum ModelRole {
 #[derive(Clone, Copy, Debug, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum AgentName {
+    CanvasGenerationAgent,
     ConversationNameAgent,
     LivenessCheckAgent,
     DataCatalogDeletionAgent,

--- a/backend/src/ai/canvas_generation_agent/agent.rs
+++ b/backend/src/ai/canvas_generation_agent/agent.rs
@@ -1,0 +1,35 @@
+use super::system_prompt::SystemPrompt;
+use super::user_prompt::UserPrompt;
+use crate::ai::agent_utils::{AgentName, ModelRole};
+use crate::ai::dto::{CanvasPlan, ConversationHistoryTurn};
+use crate::common::AppState;
+use anyhow::Result;
+use tracing::info;
+
+pub async fn execute(
+    app_state: &AppState,
+    conversation_history_turns: &[ConversationHistoryTurn],
+) -> Result<CanvasPlan> {
+    info!(
+        "canvas_generation_agent: planning canvas (history_turns={})",
+        conversation_history_turns.len()
+    );
+
+    let model_client = app_state.require_model_client().await?;
+    let agent = model_client.build_agent(
+        ModelRole::Default,
+        AgentName::CanvasGenerationAgent,
+        SystemPrompt::GenerateCanvas.as_str(),
+        0.2,
+        4096,
+    );
+
+    let prompt = UserPrompt::Generate {
+        conversation_history_turns,
+    }
+    .render();
+    let plan: CanvasPlan = agent.prompt_typed::<CanvasPlan>(prompt).await?;
+
+    info!("canvas_generation_agent: planned {} cells", plan.cells.len());
+    Ok(plan)
+}

--- a/backend/src/ai/canvas_generation_agent/mod.rs
+++ b/backend/src/ai/canvas_generation_agent/mod.rs
@@ -1,0 +1,5 @@
+mod system_prompt;
+mod user_prompt;
+
+mod agent;
+pub use agent::*;

--- a/backend/src/ai/canvas_generation_agent/system_prompt.rs
+++ b/backend/src/ai/canvas_generation_agent/system_prompt.rs
@@ -1,0 +1,32 @@
+pub enum SystemPrompt {
+    GenerateCanvas,
+}
+
+impl SystemPrompt {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SystemPrompt::GenerateCanvas => GENERATE_CANVAS,
+        }
+    }
+}
+
+const GENERATE_CANVAS: &str = r#"
+You are a data canvas planner. Given the history of an analytics conversation (user questions and the SQL that answered them), design a Canvas: a set of notebook cells, each with a single SQL query, and for cells whose result is best shown visually, an optional chart spec. Reuse and adapt the SQL already produced in the conversation. Prefer 3-8 focused cells. Return ONLY the structured plan.
+
+CHART SPEC:
+- `chart_type` must be one of: BAR, LINE, PIE, METRIC.
+- For BAR/LINE set `x_axis` and `y_axis`. For PIE set `category` and `value`. METRIC needs no axes and renders the first value of the first row.
+- All axis and category/value names MUST be column aliases produced by that cell's SQL.
+- For BAR, LINE and PIE you MUST also set `aggregate_function`, one of: MAX, MIN, SUM, COUNT, AVG. It is applied when grouping rows by `x_axis` (or `category`), so when the SQL already returns one row per group use MAX.
+
+DASHBOARD LAYOUT. Every chart is also placed on a dashboard laid out on a 12-column grid, where one row is 100px tall. Set `grid_width` (4-12 columns) and `grid_height` (3-6 rows) per chart. Charts are packed left to right in the order you list them and wrap to the next row when they no longer fit, so choose widths that add up to exactly 12 per row and avoid leaving gaps.
+
+Do NOT make everything full width — a dashboard of stacked full-width charts forces the user to scroll to the end. Guidance:
+- 4x3 is the default and fits three charts per row.
+- Use 6x3 for a pair of charts that read side by side.
+- Use 6x4 or 12x4 only for the one or two most important charts, or for a long time series that needs the width.
+- METRIC charts are single numbers, so keep them at 4x3.
+- With 3 charts use 4+4+4; with 4 use 6+6 twice; with 5 use 4+4+4 then 6+6; with 6 use 4+4+4 twice.
+
+Give the canvas a short name and one-line description summarizing the analysis.
+"#;

--- a/backend/src/ai/canvas_generation_agent/user_prompt.rs
+++ b/backend/src/ai/canvas_generation_agent/user_prompt.rs
@@ -1,0 +1,29 @@
+use crate::ai::dto::ConversationHistoryTurn;
+
+pub enum UserPrompt<'a> {
+    Generate {
+        conversation_history_turns: &'a [ConversationHistoryTurn],
+    },
+}
+
+impl<'a> UserPrompt<'a> {
+    pub fn render(&self) -> String {
+        match self {
+            UserPrompt::Generate {
+                conversation_history_turns,
+            } => {
+                let mut out = String::from(
+                    "Design a Canvas from the conversation so far.\n\nConversation history:\n",
+                );
+                for (i, turn) in conversation_history_turns.iter().enumerate() {
+                    out.push_str(&format!("\nTurn {}:\n", i + 1));
+                    out.push_str(&format!("  User: {}\n", turn.user_question));
+                    if let Some(sql) = &turn.generated_sql {
+                        out.push_str(&format!("  SQL: {}\n", sql));
+                    }
+                }
+                out
+            }
+        }
+    }
+}

--- a/backend/src/ai/dto.rs
+++ b/backend/src/ai/dto.rs
@@ -206,6 +206,7 @@ pub enum RouterCode {
     Clarify,
     RejectOffTopic,
     RejectUnsafe,
+    GenerateCanvas,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
@@ -279,6 +280,15 @@ pub enum Event {
     Routed { decision: RouterDecision },
     AwaitingClarification,
     Rejected,
+    GeneratingCanvas,
+    CanvasGenerated {
+        canvas_id: uuid::Uuid,
+        name: String,
+        description: Option<String>,
+        sql_cell_count: i32,
+        chart_cell_count: i32,
+        dashboard_charts_count: i32,
+    },
 }
 
 pub struct EventChannels {
@@ -304,6 +314,32 @@ impl Event {
     pub fn to_json_string(&self) -> String {
         serde_json::to_string(self).expect("Event JSON serialization")
     }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct CanvasPlanChart {
+    pub chart_type: crate::cell::constants::ChartType,
+    pub x_axis: Option<String>,
+    pub y_axis: Option<String>,
+    pub category: Option<String>,
+    pub value: Option<String>,
+    pub aggregate_function: Option<crate::cell::constants::AggregateFunction>,
+    pub grid_width: Option<u16>,
+    pub grid_height: Option<u16>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct CanvasPlanCell {
+    pub title: String,
+    pub sql: String,
+    pub chart: Option<CanvasPlanChart>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct CanvasPlan {
+    pub name: String,
+    pub description: Option<String>,
+    pub cells: Vec<CanvasPlanCell>,
 }
 
 #[cfg(test)]

--- a/backend/src/ai/mod.rs
+++ b/backend/src/ai/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod agent_utils;
+pub(crate) mod canvas_generation_agent;
 pub(crate) mod conversation_name_agent;
 pub(crate) mod dto;
 pub(crate) mod followup_questions_agent;

--- a/backend/src/canvas/dto.rs
+++ b/backend/src/canvas/dto.rs
@@ -11,6 +11,16 @@ pub struct CreateCanvasResult {
     pub dashboard: entity::dashboard::Model,
 }
 
+#[derive(Debug)]
+pub struct GeneratedCanvasSummary {
+    pub canvas_id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub sql_cell_count: i32,
+    pub chart_cell_count: i32,
+    pub dashboard_charts_count: i32,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateCanvasDto {
     pub name: String,

--- a/backend/src/canvas/service.rs
+++ b/backend/src/canvas/service.rs
@@ -146,6 +146,155 @@ pub async fn execute_create_canvas(
     })
 }
 
+fn chart_content_json(
+    cell_id: Uuid,
+    chart: &crate::ai::dto::CanvasPlanChart,
+) -> Result<String, sea_orm::DbErr> {
+    use crate::cell::constants::{
+        AggregateFunction, AxisMinorTickShow, AxisTickShow, ChartOrientation, ChartType,
+        MetricFormat, SortOrder,
+    };
+    use crate::cell::dto::{
+        AxisChartContent, ChartContent, MetricChartContent, PieChartContent,
+    };
+
+    let aggregate_function = chart
+        .aggregate_function
+        .clone()
+        .unwrap_or(AggregateFunction::Max)
+        .as_str()
+        .to_string();
+
+    let content = match chart.chart_type {
+        ChartType::Bar | ChartType::Line => {
+            let axis = AxisChartContent {
+                cell_id,
+                x_axis: chart.x_axis.clone().unwrap_or_default(),
+                y_axis: chart.y_axis.clone().unwrap_or_default(),
+                orientation: Some(ChartOrientation::Vertical),
+                y_axis_aggregate_function: Some(aggregate_function),
+                y_axis_sort_order: Some(SortOrder::None),
+                x_axis_tick_show: Some(AxisTickShow::Show),
+                y_axis_tick_show: Some(AxisTickShow::Show),
+                axis_minor_tick_show: Some(AxisMinorTickShow::Show),
+            };
+            match chart.chart_type {
+                ChartType::Line => ChartContent::Line(axis),
+                _ => ChartContent::Bar(axis),
+            }
+        }
+        ChartType::Pie => ChartContent::Pie(PieChartContent {
+            cell_id,
+            category: chart.category.clone().unwrap_or_default(),
+            value: chart.value.clone().unwrap_or_default(),
+            aggregate_function: Some(aggregate_function),
+        }),
+        ChartType::Metric => ChartContent::Metric(MetricChartContent {
+            cell_id,
+            decimal_precision: Some(2),
+            suffix: None,
+            format: Some(MetricFormat::Default),
+        }),
+    };
+
+    serde_json::to_string(&content)
+        .map_err(|_| sea_orm::DbErr::Custom("failed to serialize chart content".into()))
+}
+
+pub async fn generate_canvas_from_plan(
+    app_state: &AppState,
+    connection_id: Uuid,
+    plan: crate::ai::dto::CanvasPlan,
+) -> Result<dto::GeneratedCanvasSummary, sea_orm::DbErr> {
+    use crate::cell::constants::CellType;
+    use crate::cell::dto::CreateCellDto;
+    use crate::dashboard::service::{DashboardChartPlacement, DashboardGridPacker};
+
+    let created = execute_create_canvas(
+        app_state,
+        dto::CreateCanvasDto {
+            name: plan.name.clone(),
+            description: plan.description.clone(),
+        },
+    )
+    .await?;
+    let notebook_id = created.notebook.id;
+    let canvas_id = created.canvas.id;
+
+    let mut sql_cell_count = 0;
+    let mut chart_cell_count = 0;
+    let mut placements: Vec<DashboardChartPlacement> = Vec::new();
+    let mut packer = DashboardGridPacker::default();
+    let mut order = 0;
+
+    for plan_cell in plan.cells.iter() {
+        let sql_cell = cell_service::execute_create_cell(
+            app_state,
+            CreateCellDto {
+                notebook_id,
+                connection_id: Some(connection_id),
+                name: Some(plan_cell.title.clone()),
+                content: Some(plan_cell.sql.clone()),
+                display_order: Some(order),
+                cell_type: CellType::Sql,
+            },
+        )
+        .await
+        .map_err(|_| sea_orm::DbErr::Custom("failed to create sql cell".into()))?;
+        sql_cell_count += 1;
+        order += 1;
+
+        if let Some(chart) = &plan_cell.chart {
+            let chart_cell = cell_service::execute_create_cell(
+                app_state,
+                CreateCellDto {
+                    notebook_id,
+                    connection_id: Some(connection_id),
+                    name: Some(plan_cell.title.clone()),
+                    content: Some(chart_content_json(sql_cell.id, chart)?),
+                    display_order: Some(order),
+                    cell_type: CellType::Chart,
+                },
+            )
+            .await
+            .map_err(|_| sea_orm::DbErr::Custom("failed to create chart cell".into()))?;
+            chart_cell_count += 1;
+            order += 1;
+
+            let (x, y, width, height) = packer.place(chart.grid_width, chart.grid_height);
+            placements.push(DashboardChartPlacement {
+                cell_id: chart_cell.id,
+                notebook_id,
+                x,
+                y,
+                width,
+                height,
+            });
+        }
+    }
+
+    let dashboard_charts_count = placements.len() as i32;
+    if !placements.is_empty() {
+        dashboard_service::set_dashboard_layout(
+            app_state,
+            created.dashboard.id,
+            plan.name.clone(),
+            plan.description.clone(),
+            placements,
+        )
+        .await?;
+    }
+
+    Ok(dto::GeneratedCanvasSummary {
+        canvas_id,
+        name: plan.name,
+        description: plan.description,
+        sql_cell_count,
+        chart_cell_count,
+        dashboard_charts_count,
+    })
+}
+
 pub async fn get_last_modified_canvases(
     app_state: &AppState,
     limit: u64,

--- a/backend/src/cell/constants.rs
+++ b/backend/src/cell/constants.rs
@@ -474,6 +474,28 @@ pub enum ChartType {
     Metric,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum AggregateFunction {
+    Max,
+    Min,
+    Sum,
+    Count,
+    Avg,
+}
+
+impl AggregateFunction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AggregateFunction::Max => "MAX",
+            AggregateFunction::Min => "MIN",
+            AggregateFunction::Sum => "SUM",
+            AggregateFunction::Count => "COUNT",
+            AggregateFunction::Avg => "AVG",
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum CellDisplayOrderMovement {
     Up,

--- a/backend/src/conversational_analytics/command/constants.rs
+++ b/backend/src/conversational_analytics/command/constants.rs
@@ -1,0 +1,25 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Command {
+    Canvas,
+}
+
+impl Command {
+    pub fn parse(name: &str) -> Option<Command> {
+        match name.trim().to_lowercase().as_str() {
+            "canvas" => Some(Command::Canvas),
+            _ => None,
+        }
+    }
+}
+
+pub fn parse_dedup(names: &[String]) -> Vec<Command> {
+    let mut seen: Vec<Command> = Vec::new();
+    for name in names {
+        if let Some(cmd) = Command::parse(name) {
+            if !seen.contains(&cmd) {
+                seen.push(cmd);
+            }
+        }
+    }
+    seen
+}

--- a/backend/src/conversational_analytics/command/mod.rs
+++ b/backend/src/conversational_analytics/command/mod.rs
@@ -1,0 +1,1 @@
+pub mod constants;

--- a/backend/src/conversational_analytics/conversation/dto.rs
+++ b/backend/src/conversational_analytics/conversation/dto.rs
@@ -1,5 +1,6 @@
 use super::constants::ConversationStatus;
 use crate::conversational_analytics::message::dto::ConversationMessageWithContentDto;
+use crate::conversational_analytics::segment::MessageSegment;
 use crate::entity;
 use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize};
@@ -8,7 +9,7 @@ use uuid::Uuid;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateConversationDto {
     pub connection_id: Uuid,
-    pub user_message: String,
+    pub segments: Vec<MessageSegment>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -43,7 +44,7 @@ impl TryFrom<entity::conversation::Model> for ConversationDto {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AppendUserMessageDto {
-    pub user_message: String,
+    pub segments: Vec<MessageSegment>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/backend/src/conversational_analytics/conversation/service.rs
+++ b/backend/src/conversational_analytics/conversation/service.rs
@@ -7,9 +7,8 @@ use super::error::ExecuteCompletionError;
 use super::repository;
 use crate::ai::conversation_name_agent;
 use crate::ai::dto::EventChannels;
-use crate::ai::followup_questions_agent;
-use crate::data_catalog;
 use crate::ai::dto::{ConversationHistoryTerminalStatus, ConversationHistoryTurn, RouterCode};
+use crate::ai::followup_questions_agent;
 use crate::ai::router_agent;
 use crate::ai::text_to_sql_agent;
 use crate::ai::visualization_agent;
@@ -18,10 +17,11 @@ use crate::ai_configuration::service as ai_config_service;
 use crate::common::time_utils;
 use crate::common::AppState;
 use crate::connection::service as connection_service;
+use crate::conversational_analytics::command::constants::{self as command_constants, Command};
 use crate::conversational_analytics::conversation::constants::ContentType;
 use crate::conversational_analytics::conversation::constants::MessageStatus;
-use crate::conversational_analytics::conversation::constants::TERMINAL_MESSAGE_STATUSES;
 use crate::conversational_analytics::conversation::constants::CONVERSATION_HISTORY_MESSAGE_LIMIT;
+use crate::conversational_analytics::conversation::constants::TERMINAL_MESSAGE_STATUSES;
 use crate::conversational_analytics::message::constants::Sender;
 use crate::conversational_analytics::message::dto::{
     ConversationMessageDto, ConversationMessageWithContentDto, CreateConversationMessageDto,
@@ -32,6 +32,8 @@ use crate::conversational_analytics::message_content::dto::{
     ConversationMessageContentDto, CreateConversationMessageContentDto,
 };
 use crate::conversational_analytics::message_content::service as message_content_service;
+use crate::conversational_analytics::segment;
+use crate::data_catalog;
 use crate::entity;
 use axum::response::sse::{Event, Sse};
 use sea_orm::TransactionTrait;
@@ -135,21 +137,22 @@ pub async fn create_conversation(
         created_at: now,
         updated_at: now,
     };
+    let segments_json = segment::serialize_segments(&payload.segments);
+    let plain_text = segment::plain_text_from_segments(&payload.segments);
+
     let txn = app_state.database_connection.begin().await?;
 
     let saved_conversation = repository::save_conversation_transaction(&txn, conversation).await?;
 
-    let user_message = CreateConversationMessageDto::initial_user_message(
-        saved_conversation.id,
-        &payload.user_message,
-    );
+    let user_message =
+        CreateConversationMessageDto::initial_user_message(saved_conversation.id, &plain_text);
     let created_message = message_service::create_message(&txn, user_message).await?;
 
     let user_message_content = CreateConversationMessageContentDto {
         conversation_message_id: created_message.id,
         sequence_number: 1,
         content_type: ContentType::Text.to_string(),
-        content: payload.user_message.clone(),
+        content: segments_json,
         status: MessageStatus::Processed.to_string(),
     };
     message_content_service::create_message_content(&txn, user_message_content).await?;
@@ -274,13 +277,24 @@ pub async fn append_user_message(
         return Err(AppendUserMessageError::ConversationBusy);
     }
 
-    let question = validate_question(&payload.user_message).map_err(|e| match e {
-        ExecuteCompletionError::EmptyQuestion => AppendUserMessageError::EmptyQuestion,
-        ExecuteCompletionError::QuestionTooLong => AppendUserMessageError::QuestionTooLong,
-        _ => AppendUserMessageError::Database(sea_orm::DbErr::Custom(
-            "unexpected validation error".to_string(),
-        )),
-    })?;
+    let segments_json = segment::serialize_segments(&payload.segments);
+    let plain_text = segment::plain_text_from_segments(&payload.segments);
+    let commands =
+        command_constants::parse_dedup(&segment::command_names_from_segments(&payload.segments));
+
+    let question: String = if plain_text.trim().is_empty() && !commands.is_empty() {
+        String::new()
+    } else {
+        validate_question(&plain_text)
+            .map_err(|e| match e {
+                ExecuteCompletionError::EmptyQuestion => AppendUserMessageError::EmptyQuestion,
+                ExecuteCompletionError::QuestionTooLong => AppendUserMessageError::QuestionTooLong,
+                _ => AppendUserMessageError::Database(sea_orm::DbErr::Custom(
+                    "unexpected validation error".to_string(),
+                )),
+            })?
+            .to_string()
+    };
 
     let txn = app_state.database_connection.begin().await?;
 
@@ -288,7 +302,7 @@ pub async fn append_user_message(
         conversation_id,
         sequence_number: last_message.sequence_number + 1,
         sender: Sender::Human.to_string(),
-        content: question.to_string(),
+        content: question.clone(),
         status: MessageStatus::Processed.to_string(),
     };
     let created_message = message_service::create_message(&txn, new_message).await?;
@@ -297,7 +311,7 @@ pub async fn append_user_message(
         conversation_message_id: created_message.id,
         sequence_number: 1,
         content_type: ContentType::Text.to_string(),
-        content: question.to_string(),
+        content: segments_json,
         status: MessageStatus::Processed.to_string(),
     };
     message_content_service::create_message_content(&txn, user_message_content).await?;
@@ -321,7 +335,7 @@ fn validate_question(question: &str) -> Result<&str, ExecuteCompletionError> {
 async fn resolve_last_human_question_for_completion(
     app_state: &AppState,
     conversation_id: Uuid,
-) -> Result<(String, i32), ExecuteCompletionError> {
+) -> Result<(String, Vec<Command>, i32), ExecuteCompletionError> {
     let last_message = message_service::get_last_message_for_conversation(
         &app_state.database_connection,
         conversation_id,
@@ -340,10 +354,17 @@ async fn resolve_last_human_question_for_completion(
     if message_contents.len() != 1 {
         return Err(ExecuteCompletionError::InvalidLastMessageContent);
     }
-    let message_content = &message_contents[0];
+    let raw = &message_contents[0].content;
 
-    let question = validate_question(&message_content.content)?;
-    Ok((question.to_string(), last_message.sequence_number))
+    let text = segment::extract_plain_text(raw);
+    let commands = command_constants::parse_dedup(&segment::command_names_from_content(raw));
+
+    let question = if text.trim().is_empty() && !commands.is_empty() {
+        String::new()
+    } else {
+        validate_question(&text)?.to_string()
+    };
+    Ok((question, commands, last_message.sequence_number))
 }
 
 async fn create_conversation_message_for_completion(
@@ -374,9 +395,6 @@ pub async fn execute_completion(
 ) -> Result<Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>>, ExecuteCompletionError>
 {
     ensure_ai_live(&app_state).await?;
-    let (question, last_message_sequence_number) =
-        resolve_last_human_question_for_completion(&app_state, conversation_id).await?;
-
     let conversation =
         repository::get_conversation(&app_state.database_connection, conversation_id)
             .await
@@ -384,7 +402,8 @@ pub async fn execute_completion(
                 sea_orm::DbErr::RecordNotFound(_) => ExecuteCompletionError::ConversationNotFound,
                 _ => ExecuteCompletionError::Database(e),
             })?;
-
+    let (question, commands, last_message_sequence_number) =
+        resolve_last_human_question_for_completion(&app_state, conversation_id).await?;
     let connection =
         connection_service::execute_get_connection(&app_state, conversation.connection_id)
             .await
@@ -392,7 +411,6 @@ pub async fn execute_completion(
                 sea_orm::DbErr::RecordNotFound(_) => ExecuteCompletionError::ConnectionNotFound,
                 _ => ExecuteCompletionError::Database(e),
             })?;
-
     let conversation_message_id = create_conversation_message_for_completion(
         &app_state,
         conversation_id,
@@ -414,6 +432,7 @@ pub async fn execute_completion(
                 &app_state,
                 &connection,
                 &question,
+                &commands,
                 &conversation_history_turns,
                 &channels,
             )
@@ -453,16 +472,49 @@ pub async fn execute_completion(
     ))
 }
 
+fn resolve_command_decision(
+    command: Command,
+    history: &[ConversationHistoryTurn],
+) -> crate::ai::dto::RouterDecision {
+    use crate::ai::dto::{RouterCode, RouterDecision};
+    match command {
+        Command::Canvas => {
+            let has_data = history.iter().any(|t| {
+                matches!(
+                    t.terminal_status,
+                    ConversationHistoryTerminalStatus::Completed
+                ) && t.generated_sql.is_some()
+            });
+            if has_data {
+                RouterDecision {
+                    code: RouterCode::GenerateCanvas,
+                    message: String::new(),
+                }
+            } else {
+                RouterDecision {
+                    code: RouterCode::Clarify,
+                    message: "I can generate a canvas once we've run at least one query in this conversation. Ask a data question first, then use /canvas.".to_string(),
+                }
+            }
+        }
+    }
+}
+
 async fn run_pipeline(
     app_state: &AppState,
     connection: &entity::connection::Model,
     question: &str,
+    commands: &[Command],
     conversation_history_turns: &[ConversationHistoryTurn],
     channels: &EventChannels,
 ) -> anyhow::Result<PipelineOutcome> {
     channels.send(crate::ai::dto::Event::Starting).await?;
     channels.send(crate::ai::dto::Event::Routing).await?;
-    let decision = router_agent::execute(app_state, question, conversation_history_turns).await?;
+    let decision = if let Some(command) = commands.first() {
+        resolve_command_decision(*command, conversation_history_turns)
+    } else {
+        router_agent::execute(app_state, question, conversation_history_turns).await?
+    };
     channels
         .send(crate::ai::dto::Event::Routed {
             decision: decision.clone(),
@@ -493,6 +545,29 @@ async fn run_pipeline(
                 channels,
             )
             .await;
+            channels.send(crate::ai::dto::Event::Completed).await?;
+            Ok(PipelineOutcome::Completed)
+        }
+        RouterCode::GenerateCanvas => {
+            channels
+                .send(crate::ai::dto::Event::GeneratingCanvas)
+                .await?;
+            let plan =
+                crate::ai::canvas_generation_agent::execute(app_state, conversation_history_turns)
+                    .await?;
+            let summary =
+                crate::canvas::service::generate_canvas_from_plan(app_state, connection.id, plan)
+                    .await?;
+            channels
+                .send(crate::ai::dto::Event::CanvasGenerated {
+                    canvas_id: summary.canvas_id,
+                    name: summary.name,
+                    description: summary.description,
+                    sql_cell_count: summary.sql_cell_count,
+                    chart_cell_count: summary.chart_cell_count,
+                    dashboard_charts_count: summary.dashboard_charts_count,
+                })
+                .await?;
             channels.send(crate::ai::dto::Event::Completed).await?;
             Ok(PipelineOutcome::Completed)
         }
@@ -642,7 +717,7 @@ async fn load_message_text(db: &sea_orm::DatabaseConnection, message_id: Uuid) -
         Ok(contents) => contents
             .into_iter()
             .next()
-            .map(|c| c.content)
+            .map(|c| segment::extract_plain_text(&c.content))
             .unwrap_or_default(),
         Err(_) => String::new(),
     }

--- a/backend/src/conversational_analytics/mod.rs
+++ b/backend/src/conversational_analytics/mod.rs
@@ -1,5 +1,7 @@
+pub mod command;
 pub mod conversation;
 pub mod message;
 pub mod message_content;
+pub mod segment;
 
 pub use conversation::routes;

--- a/backend/src/conversational_analytics/segment.rs
+++ b/backend/src/conversational_analytics/segment.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum MessageSegment {
+    Text { text: String },
+    Command { name: String },
+}
+
+pub fn serialize_segments(segments: &[MessageSegment]) -> String {
+    serde_json::to_string(segments).unwrap_or_default()
+}
+
+pub fn plain_text_from_segments(segments: &[MessageSegment]) -> String {
+    segments
+        .iter()
+        .filter_map(|s| match s {
+            MessageSegment::Text { text } => Some(text.as_str()),
+            MessageSegment::Command { .. } => None,
+        })
+        .collect::<String>()
+}
+
+pub fn command_names_from_segments(segments: &[MessageSegment]) -> Vec<String> {
+    segments
+        .iter()
+        .filter_map(|s| match s {
+            MessageSegment::Command { name } => Some(name.clone()),
+            MessageSegment::Text { .. } => None,
+        })
+        .collect()
+}
+
+pub fn extract_plain_text(content: &str) -> String {
+    match serde_json::from_str::<Vec<MessageSegment>>(content) {
+        Ok(segments) => plain_text_from_segments(&segments),
+        Err(_) => content.to_string(),
+    }
+}
+
+pub fn command_names_from_content(content: &str) -> Vec<String> {
+    match serde_json::from_str::<Vec<MessageSegment>>(content) {
+        Ok(segments) => command_names_from_segments(&segments),
+        Err(_) => Vec::new(),
+    }
+}

--- a/backend/src/dashboard/constants.rs
+++ b/backend/src/dashboard/constants.rs
@@ -1,6 +1,13 @@
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+pub const GRID_COLUMN_COUNT: u16 = 12;
+pub const MIN_CHART_WIDTH: u16 = 4;
+pub const MIN_CHART_HEIGHT: u16 = 3;
+pub const MAX_CHART_HEIGHT: u16 = 6;
+pub const DEFAULT_CHART_WIDTH: u16 = 4;
+pub const DEFAULT_CHART_HEIGHT: u16 = 3;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum DashboardStatus {
     Active,

--- a/backend/src/dashboard/service.rs
+++ b/backend/src/dashboard/service.rs
@@ -1,5 +1,6 @@
 use crate::common::time_utils;
 use crate::common::AppState;
+use crate::dashboard::constants;
 use crate::dashboard::constants::DashboardStatus;
 use crate::dashboard::dto;
 use crate::dashboard::dto::Layout;
@@ -128,6 +129,65 @@ pub async fn execute_update_dashboard(
     dashboard_id: Uuid,
     payload: dto::DashboardDto,
 ) -> Result<entity::dashboard::Model, sea_orm::DbErr> {
+    repository::update_dashboard(&app_state.database_connection, dashboard_id, payload).await
+}
+
+pub struct DashboardChartPlacement {
+    pub cell_id: Uuid,
+    pub notebook_id: Uuid,
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub height: u16,
+}
+
+#[derive(Default)]
+pub struct DashboardGridPacker {
+    x: u16,
+    y: u16,
+    row_height: u16,
+}
+
+impl DashboardGridPacker {
+    pub fn place(&mut self, width: Option<u16>, height: Option<u16>) -> (u16, u16, u16, u16) {
+        let width = width
+            .unwrap_or(constants::DEFAULT_CHART_WIDTH)
+            .clamp(constants::MIN_CHART_WIDTH, constants::GRID_COLUMN_COUNT);
+        let height = height
+            .unwrap_or(constants::DEFAULT_CHART_HEIGHT)
+            .clamp(constants::MIN_CHART_HEIGHT, constants::MAX_CHART_HEIGHT);
+
+        if self.x + width > constants::GRID_COLUMN_COUNT {
+            self.y += self.row_height;
+            self.x = 0;
+            self.row_height = 0;
+        }
+
+        let placement = (self.x, self.y, width, height);
+        self.x += width;
+        self.row_height = self.row_height.max(height);
+        placement
+    }
+}
+
+pub async fn set_dashboard_layout(
+    app_state: &AppState,
+    dashboard_id: Uuid,
+    name: String,
+    description: Option<String>,
+    charts: Vec<DashboardChartPlacement>,
+) -> Result<entity::dashboard::Model, sea_orm::DbErr> {
+    let layout: Vec<Layout> = charts
+        .into_iter()
+        .map(|c| Layout::new(c.cell_id, c.notebook_id, c.x, c.y, c.width, c.height))
+        .collect();
+    let payload = dto::DashboardDto {
+        id: dashboard_id,
+        name: Some(name),
+        description,
+        layout: Some(layout),
+        status: DashboardStatus::Active,
+    };
     repository::update_dashboard(&app_state.database_connection, dashboard_id, payload).await
 }
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -48,6 +48,7 @@
         "@tiptap/extensions": "^3.20.4",
         "@tiptap/pm": "^3.20.4",
         "@tiptap/react": "^3.20.4",
+        "@tiptap/suggestion": "^3.26.0",
         "@types/lodash.debounce": "^4.0.9",
         "@types/react-cookies": "^0.1.4",
         "classnames": "^2.5.1",
@@ -3686,12 +3687,6 @@
         "url": "https://opencollective.com/immer"
       }
     },
-    "node_modules/@remirror/core-constants": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
-      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
-      "license": "MIT"
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -4184,9 +4179,9 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.0.tgz",
-      "integrity": "sha512-EA/XFbvvz0yRyccqrgOwB9RQe6+uJ8NszjLKH9+3xPE2/+Sa2imax0IqWl7YOXkWihdQVrlpP+EpQF9APKx3jg==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.26.0.tgz",
+      "integrity": "sha512-7jTed/RirIVsp+lLdLvGzGqF3EBGpnGHGYKOwz6t28V2BIJLAFdUhfEVdWie7xPxQNWK0TP+fPlsqZS0vxfHBg==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -4194,7 +4189,7 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.22.0"
+        "@tiptap/pm": "3.26.0"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
@@ -4501,29 +4496,24 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.0.tgz",
-      "integrity": "sha512-O9kpzNnFX5837kFevwAM8yr7ImLHu8noIwIpoci0AwfJjiBMzfZBejhbzxnKEfTpFWnkvZ8rWohlb6CQdJ6Crg==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.26.0.tgz",
+      "integrity": "sha512-q4RDeWwVrhOL0jJCGRgGxLSdjOYwzQ4h2InURZVhC66433ipcHd6f3bqSOhcXZ4r0sFmMNsuF7aZmUntjWLc7w==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
-        "prosemirror-collab": "^1.3.1",
         "prosemirror-commands": "^1.6.2",
         "prosemirror-dropcursor": "^1.8.1",
         "prosemirror-gapcursor": "^1.3.2",
         "prosemirror-history": "^1.4.1",
         "prosemirror-inputrules": "^1.4.0",
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-markdown": "^1.13.1",
-        "prosemirror-menu": "^1.2.4",
-        "prosemirror-model": "^1.24.1",
-        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.7",
         "prosemirror-schema-list": "^1.5.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.4",
-        "prosemirror-trailing-node": "^3.0.0",
-        "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.38.1"
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-tables": "^1.8.0",
+        "prosemirror-transform": "^1.12.0",
+        "prosemirror-view": "^1.41.8"
       },
       "funding": {
         "type": "github",
@@ -4564,6 +4554,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@tiptap/suggestion": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.26.0.tgz",
+      "integrity": "sha512-3jxBvjmfooQroR0eCw61kSgr+g90KFVD3dM5bANhpQbCpCYRydp/iXDQmpoPHjv8FpeU5JZgcnJ3R9vhjeIM2A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.26.0",
+        "@tiptap/pm": "3.26.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -4736,12 +4740,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT"
-    },
     "node_modules/@types/lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
@@ -4756,22 +4754,6 @@
       "dependencies": {
         "@types/lodash": "*"
       }
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.1.2",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
-      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/linkify-it": "^5",
-        "@types/mdurl": "^2"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -5226,6 +5208,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -5625,18 +5608,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/es-toolkit": {
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
@@ -5702,6 +5673,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6280,15 +6252,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/linkifyjs": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
@@ -6355,34 +6318,11 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
     "node_modules/material-symbols": {
       "version": "0.31.2",
       "resolved": "https://registry.npmjs.org/material-symbols/-/material-symbols-0.31.2.tgz",
       "integrity": "sha512-WANME7n9kqLNG1mcdcTuvbxkMuBQ64ktK/18d44/p/wZF0XkYXjXWs62cp4qnYGjtWABvUM3ZTB096MJsLbNSw==",
       "license": "Apache-2.0"
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -6670,15 +6610,6 @@
         "prosemirror-transform": "^1.0.0"
       }
     },
-    "node_modules/prosemirror-collab": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
-      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-commands": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
@@ -6745,45 +6676,13 @@
         "w3c-keyname": "^2.2.0"
       }
     },
-    "node_modules/prosemirror-markdown": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
-      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/markdown-it": "^14.0.0",
-        "markdown-it": "^14.0.0",
-        "prosemirror-model": "^1.25.0"
-      }
-    },
-    "node_modules/prosemirror-menu": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.0.tgz",
-      "integrity": "sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==",
-      "license": "MIT",
-      "dependencies": {
-        "crelt": "^1.0.0",
-        "prosemirror-commands": "^1.0.0",
-        "prosemirror-history": "^1.0.0",
-        "prosemirror-state": "^1.0.0"
-      }
-    },
     "node_modules/prosemirror-model": {
-      "version": "1.25.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
-      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "version": "1.25.7",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
+      "integrity": "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==",
       "license": "MIT",
       "dependencies": {
         "orderedmap": "^2.0.0"
-      }
-    },
-    "node_modules/prosemirror-schema-basic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
-      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-model": "^1.25.0"
       }
     },
     "node_modules/prosemirror-schema-list": {
@@ -6821,34 +6720,19 @@
         "prosemirror-view": "^1.41.4"
       }
     },
-    "node_modules/prosemirror-trailing-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
-      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@remirror/core-constants": "3.0.0",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.22.1",
-        "prosemirror-state": "^1.4.2",
-        "prosemirror-view": "^1.33.8"
-      }
-    },
     "node_modules/prosemirror-transform": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.11.0.tgz",
-      "integrity": "sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.21.0"
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.41.7",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.7.tgz",
-      "integrity": "sha512-jUwKNCEIGiqdvhlS91/2QAg21e4dfU5bH2iwmSDQeosXJgKF7smG0YSplOWK0cjSNgIqXe7VXqo7EIfUFJdt3w==",
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-model": "^1.20.0",
@@ -6861,15 +6745,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7388,12 +7263,6 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
-    },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
     "@tiptap/extensions": "^3.20.4",
     "@tiptap/pm": "^3.20.4",
     "@tiptap/react": "^3.20.4",
+    "@tiptap/suggestion": "^3.26.0",
     "@types/lodash.debounce": "^4.0.9",
     "@types/react-cookies": "^0.1.4",
     "classnames": "^2.5.1",

--- a/frontend/src/api/conversational_analytics/queries.tsx
+++ b/frontend/src/api/conversational_analytics/queries.tsx
@@ -20,6 +20,7 @@ export type {
   ConversationMessageDto,
   ConversationWithMessagesDto,
   AppendUserMessageDto,
+  MessageSegment,
 } from "src/components/ConversationalAnalytics/dto";
 
 export {

--- a/frontend/src/components/ConversationalAnalytics/AgentTrace/AgentTrace.tsx
+++ b/frontend/src/components/ConversationalAnalytics/AgentTrace/AgentTrace.tsx
@@ -10,11 +10,13 @@ import {
 import { rotateToggleTransition } from "src/components/design-system/animation";
 import {
   AgentEventName,
+  extractCanvasGenerated,
   type AgentEvent,
   type ConversationMessageContentDto,
   type GeneratedSqlData,
   type RecommendedVisualizationData,
 } from "src/components/ConversationalAnalytics/dto";
+import { CanvasGeneratedCard } from "src/components/ConversationalAnalytics/CanvasGeneratedCard";
 import {
   parseEvent,
   isCompletedEvent,
@@ -68,6 +70,8 @@ export function AgentTrace({ connectionId, contents }: AgentTraceProps) {
       ? (event.data as RecommendedVisualizationData).visualization
       : null;
   }, [events]);
+
+  const canvas = useMemo(() => extractCanvasGenerated(events), [events]);
 
   if (events.length === 0 && !routerDecision) return null;
 
@@ -141,6 +145,7 @@ export function AgentTrace({ connectionId, contents }: AgentTraceProps) {
           visualization={visualization}
         />
       )}
+      {canvas && <CanvasGeneratedCard data={canvas} />}
     </>
   );
 }

--- a/frontend/src/components/ConversationalAnalytics/AgentTrace/trace-steps.tsx
+++ b/frontend/src/components/ConversationalAnalytics/AgentTrace/trace-steps.tsx
@@ -69,6 +69,7 @@ export const STEP_LABELS: Record<string, string> = {
   [AgentEventName.ExecutingQuery]: "Executing Query",
   [AgentEventName.RecommendingVisualization]: "Recommending Visualization",
   [AgentEventName.RecommendedVisualization]: "Recommended Visualization",
+  [AgentEventName.GeneratingCanvas]: "Generating canvas…",
 };
 
 export const TRACE_HIDDEN_EVENTS = new Set<string>([
@@ -81,6 +82,7 @@ export const TRACE_HIDDEN_EVENTS = new Set<string>([
   AgentEventName.ExecutedQuery,
   AgentEventName.RecommendedVisualization,
   AgentEventName.SuggestedFollowups,
+  AgentEventName.CanvasGenerated,
 ]);
 
 const OBSERVATION_COLUMNS: ColumnConfig<EmpericalObservationColumn>[] = [
@@ -441,7 +443,12 @@ export function extractRouterDecision(
 }
 
 const ROUTER_DECISION_BADGE: Record<
-  Exclude<RouterCode, typeof RouterCode.TextToSql | typeof RouterCode.Followup>,
+  Exclude<
+    RouterCode,
+    | typeof RouterCode.TextToSql
+    | typeof RouterCode.Followup
+    | typeof RouterCode.GenerateCanvas
+  >,
   { label: string; variant: NonNullable<BadgeProps["variant"]> }
 > = {
   [RouterCode.Clarify]: { label: "Clarification", variant: "yellow" },
@@ -463,10 +470,14 @@ export function RouterDecisionBubble({
   createdAt?: string;
 }) {
   const { code, message } = data.decision;
-  if (code === RouterCode.TextToSql || code === RouterCode.Followup)
-    return null;
+  const badge = ROUTER_DECISION_BADGE[
+    code as keyof typeof ROUTER_DECISION_BADGE
+  ] as
+    | (typeof ROUTER_DECISION_BADGE)[keyof typeof ROUTER_DECISION_BADGE]
+    | undefined;
+  if (!badge) return null;
 
-  const { label, variant } = ROUTER_DECISION_BADGE[code];
+  const { label, variant } = badge;
 
   return (
     <Flex direction="column" className={panelStyles.messageBubbleGroup}>
@@ -605,7 +616,11 @@ export function TraceStep({
           </Box>
         </Flex>
         <Flex gap="2xs" sx={{ minHeight: !isLast ? "16px" : undefined }}>
-          <Flex direction="column" alignItems="center" className={styles.stepLineColumn}>
+          <Flex
+            direction="column"
+            alignItems="center"
+            className={styles.stepLineColumn}
+          >
             {!isLast && <Box className={styles.stepLine} />}
           </Flex>
           {expandable && (

--- a/frontend/src/components/ConversationalAnalytics/CanvasGeneratedCard.tsx
+++ b/frontend/src/components/ConversationalAnalytics/CanvasGeneratedCard.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useMemo } from "react";
+import { Link, useNavigate } from "react-router";
+import { Card, Flex, Badge, Icon, ToolTip, Text } from "src/components/design-system";
+import type { IconType } from "src/components/design-system/datatypes";
+import { APP_ROUTES } from "src/constants/app_routes";
+import type { CanvasGeneratedData } from "src/components/ConversationalAnalytics/dto";
+
+type CanvasStatProps = {
+  iconType: IconType;
+  count: number;
+  tooltipText: string;
+};
+
+function CanvasStat({ iconType, count, tooltipText }: CanvasStatProps) {
+  return (
+    <ToolTip messageElement={<Text>{tooltipText}</Text>} tooltipSide="top">
+      <Flex gap="xs" alignItems="center">
+        <Icon type={iconType} color="grey" />
+        <Badge variant="subtle">{count}</Badge>
+      </Flex>
+    </ToolTip>
+  );
+}
+
+type CanvasGeneratedCardProps = {
+  data: CanvasGeneratedData;
+};
+
+const LINK_STYLE = { color: "inherit", textDecoration: "none" };
+const CARD_STYLE = { transformOrigin: "left center" };
+
+export function CanvasGeneratedCard({ data }: CanvasGeneratedCardProps) {
+  const navigate = useNavigate();
+  const canvasPath = useMemo(
+    () => APP_ROUTES.CANVAS.replace(":id", data.canvas_id),
+    [data.canvas_id]
+  );
+
+  const handleClick = useCallback(() => {
+    if (window.getSelection()?.toString()) return;
+    navigate(canvasPath);
+  }, [canvasPath, navigate]);
+
+  const handleLinkClick = useCallback((event: React.MouseEvent) => {
+    event.stopPropagation();
+  }, []);
+
+  return (
+    <Card onClick={handleClick} sx={CARD_STYLE}>
+      <Card.Header baseAccessbilityLevel={2}>
+        <Link to={canvasPath} style={LINK_STYLE} onClick={handleLinkClick}>
+          <Card.Title>{data.name}</Card.Title>
+        </Link>
+        <Card.Description>{data.description}</Card.Description>
+      </Card.Header>
+      <Card.Content>
+        <Flex gap="lg" alignItems="center" sx={{ flexWrap: "wrap" }}>
+          <CanvasStat
+            iconType="table"
+            count={data.sql_cell_count}
+            tooltipText="SQL Cells"
+          />
+          <CanvasStat
+            iconType="bar_chart"
+            count={data.chart_cell_count}
+            tooltipText="Chart Cells"
+          />
+          <CanvasStat
+            iconType="layout_dashboard"
+            count={data.dashboard_charts_count}
+            tooltipText="Dashboard Charts"
+          />
+        </Flex>
+      </Card.Content>
+    </Card>
+  );
+}

--- a/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/ExistingConversationPanel.tsx
+++ b/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/ExistingConversationPanel.tsx
@@ -23,8 +23,14 @@ import {
   useStartStream,
 } from "src/components/ConversationalAnalytics/ConversationStreamContext";
 import type { MessageComposerHandle } from "src/components/ConversationalAnalytics/MessageComposer";
+import type { MessageSegment } from "src/api/conversational_analytics/queries";
 import { extractFollowUpQuestions } from "src/components/ConversationalAnalytics/dto";
 import { SuggestedQuestionList } from "src/components/ConversationalAnalytics/SuggestedQuestionList";
+import {
+  MessageSegments,
+  parseMessageSegments,
+  segmentsToText,
+} from "src/components/ConversationalAnalytics/MessageSegments";
 
 type MessageProps = {
   connectionId: string;
@@ -34,10 +40,12 @@ type MessageProps = {
 const Message = ({ connectionId, message }: MessageProps) => {
   const render = () => {
     if (message.sender == Sender.Human) {
-      const text = [...message.content]
+      const rawContent = [...message.content]
         .sort((a, b) => a.sequence_number - b.sequence_number)
         .map((c) => c.content)
         .join("\n");
+      const segments = parseMessageSegments(rawContent);
+      const text = segments ? segmentsToText(segments) : rawContent;
       return (
         <Flex direction="column" className={styles.messageBubbleGroup}>
           <Flex
@@ -46,7 +54,7 @@ const Message = ({ connectionId, message }: MessageProps) => {
             paddingX="md"
             paddingY="md"
           >
-            {text}
+            {segments ? <MessageSegments segments={segments} /> : rawContent}
           </Flex>
           <MessageHoverFooter
             createdAt={message.created_at}
@@ -93,10 +101,10 @@ export const ExistingConversationPanel = () => {
 
   const connectionId = conversationQuery.data?.conversation.connection_id ?? "";
 
-  const handleSubmit = (text: string) => {
+  const handleSubmit = (segments: MessageSegment[]) => {
     if (!gate.canSend) return;
     appendUserMessage.mutate(
-      { user_message: text },
+      { segments },
       {
         onSuccess: () => {
           startStream(conversationId);

--- a/frontend/src/components/ConversationalAnalytics/MessageComposer/MessageComposer.tsx
+++ b/frontend/src/components/ConversationalAnalytics/MessageComposer/MessageComposer.tsx
@@ -31,6 +31,12 @@ import {
   UndoRedo,
 } from "@tiptap/extensions";
 import { Box, Flex, IconButton } from "src/components/design-system";
+import {
+  EditorNodeName,
+  SlashCommandExtension,
+  isSlashSuggestionActive,
+} from "./SlashCommandExtension";
+import type { MessageSegment } from "src/components/ConversationalAnalytics/dto";
 import styles from "./MessageComposer.module.css";
 
 export type MessageComposerHandle = {
@@ -39,7 +45,7 @@ export type MessageComposerHandle = {
 
 type MessageComposerProps = {
   placeholder: string;
-  onSubmit: (text: string) => void;
+  onSubmit: (segments: MessageSegment[]) => void;
   disabled: boolean;
   disabledTooltip?: string;
   enabledTooltip?: string;
@@ -47,11 +53,21 @@ type MessageComposerProps = {
   ref?: Ref<MessageComposerHandle>;
 };
 
-const extractAndClear = (editor: Editor): string | null => {
-  const text = editor.getText().trim();
-  if (!text) return null;
-  editor.commands.clearContent(true);
-  return text;
+const extractSegments = (editor: Editor): MessageSegment[] => {
+  const segments: MessageSegment[] = [];
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === EditorNodeName.SlashCommand) {
+      segments.push({ type: "COMMAND", name: node.attrs.commandName });
+    } else if (node.isText && node.text) {
+      segments.push({ type: "TEXT", text: node.text });
+    } else if (node.type.name === "paragraph" && segments.length > 0) {
+      const last = segments[segments.length - 1];
+      if (last.type === "TEXT" && !last.text.endsWith("\n")) {
+        last.text += "\n";
+      }
+    }
+  });
+  return segments;
 };
 
 export function MessageComposer({
@@ -87,6 +103,7 @@ export function MessageComposer({
       TrailingNode,
       Underline,
       UndoRedo,
+      SlashCommandExtension,
       Placeholder.configure({
         placeholder,
         emptyEditorClass: "is-editor-empty",
@@ -99,10 +116,15 @@ export function MessageComposer({
       },
       handleKeyDown: (_view, event) => {
         if (event.key === "Enter" && !event.shiftKey) {
+          if (editor && isSlashSuggestionActive(editor)) return false;
           event.preventDefault();
           if (disabled || !editor) return true;
-          const text = extractAndClear(editor);
-          if (text !== null) onSubmit(text);
+          const segments = extractSegments(editor);
+          const text = editor.getText().trim();
+          const hasCommand = segments.some((s) => s.type === "COMMAND");
+          if (!text && !hasCommand) return true;
+          editor.commands.clearContent(true);
+          onSubmit(segments);
           return true;
         }
         return false;
@@ -126,8 +148,12 @@ export function MessageComposer({
 
   const handleClickSend = () => {
     if (disabled || !editor) return;
-    const text = extractAndClear(editor);
-    if (text !== null) onSubmit(text);
+    const segments = extractSegments(editor);
+    const text = editor.getText().trim();
+    const hasCommand = segments.some((s) => s.type === "COMMAND");
+    if (!text && !hasCommand) return;
+    editor.commands.clearContent(true);
+    onSubmit(segments);
   };
 
   return (
@@ -173,5 +199,3 @@ export function MessageComposer({
     </EditorContext.Provider>
   );
 }
-
-MessageComposer.displayName = "MessageComposer";

--- a/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandBadge.tsx
+++ b/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandBadge.tsx
@@ -1,0 +1,11 @@
+import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
+import { Badge } from "src/components/design-system";
+
+export function SlashCommandBadge({ node }: NodeViewProps) {
+  const commandName = node.attrs.commandName as string;
+  return (
+    <NodeViewWrapper as="span" contentEditable={false}>
+      <Badge variant="command" shape="rounded" size="sm">{`/${commandName}`}</Badge>
+    </NodeViewWrapper>
+  );
+}

--- a/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandExtension.tsx
+++ b/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandExtension.tsx
@@ -1,0 +1,123 @@
+import { Node, mergeAttributes, type Editor } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+import Suggestion, {
+  type SuggestionOptions,
+  type SuggestionProps,
+} from "@tiptap/suggestion";
+import { PluginKey } from "@tiptap/pm/state";
+import { createRoot, type Root } from "react-dom/client";
+import { createElement, createRef } from "react";
+import { SlashCommandBadge } from "./SlashCommandBadge";
+import {
+  SlashCommandList,
+  type SlashCommandListHandle,
+} from "./SlashCommandList";
+
+export enum EditorNodeName {
+  SlashCommand = "slashCommand",
+}
+
+export type SlashCommand = { name: string; description: string };
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  { name: "canvas", description: "Generate canvas for the conversation" },
+];
+
+const slashCommandPluginKey = new PluginKey(EditorNodeName.SlashCommand);
+
+export const isSlashSuggestionActive = (editor: Editor): boolean =>
+  slashCommandPluginKey.getState(editor.state)?.active ?? false;
+
+const suggestion: Omit<SuggestionOptions<SlashCommand>, "editor"> = {
+  char: "/",
+  pluginKey: slashCommandPluginKey,
+  items: ({ query }) =>
+    SLASH_COMMANDS.filter((command) =>
+      command.name.toLowerCase().startsWith(query.toLowerCase()),
+    ),
+  command: ({ editor, range, props }) => {
+    editor
+      .chain()
+      .focus()
+      .insertContentAt(range, [
+        {
+          type: EditorNodeName.SlashCommand,
+          attrs: { commandName: props.name },
+        },
+        { type: "text", text: " " },
+      ])
+      .run();
+  },
+  render: () => {
+    let container: HTMLDivElement | null = null;
+    let root: Root | null = null;
+    const listRef = createRef<SlashCommandListHandle>();
+
+    const renderList = (props: SuggestionProps<SlashCommand>) => {
+      root?.render(
+        createElement(SlashCommandList, {
+          ref: listRef,
+          items: props.items,
+          command: props.command,
+          clientRect: props.clientRect,
+        }),
+      );
+    };
+
+    return {
+      onStart: (props) => {
+        container = document.createElement("div");
+        document.body.appendChild(container);
+        root = createRoot(container);
+        renderList(props);
+      },
+      onUpdate: (props) => renderList(props),
+      onKeyDown: (props) => {
+        if (props.event.key === "Escape") return true;
+        return listRef.current?.onKeyDown(props.event) ?? false;
+      },
+      onExit: () => {
+        root?.unmount();
+        container?.remove();
+        root = null;
+        container = null;
+      },
+    };
+  },
+};
+
+export const SlashCommandExtension = Node.create({
+  name: EditorNodeName.SlashCommand,
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      commandName: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-slash-command"),
+        renderHTML: (attributes) => ({
+          "data-slash-command": attributes.commandName,
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "span[data-slash-command]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ["span", mergeAttributes(HTMLAttributes)];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(SlashCommandBadge);
+  },
+
+  addProseMirrorPlugins() {
+    return [Suggestion({ editor: this.editor, ...suggestion })];
+  },
+});

--- a/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandList.tsx
+++ b/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandList.tsx
@@ -1,0 +1,91 @@
+import {
+  useEffect,
+  useImperativeHandle,
+  useState,
+  type Ref,
+} from "react";
+import { DropdownMenu } from "src/components/design-system";
+import type { SlashCommand } from "./SlashCommandExtension";
+
+export type SlashCommandListHandle = {
+  onKeyDown: (event: KeyboardEvent) => boolean;
+};
+
+type SlashCommandListProps = {
+  items: SlashCommand[];
+  command: (item: SlashCommand) => void;
+  clientRect?: (() => DOMRect | null) | null;
+  ref?: Ref<SlashCommandListHandle>;
+};
+
+export function SlashCommandList({
+  items,
+  command,
+  clientRect,
+  ref,
+}: SlashCommandListProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useEffect(() => setSelectedIndex(0), [items]);
+
+  const selectItem = (index: number) => {
+    const item = items[index];
+    if (item) command(item);
+  };
+
+  useImperativeHandle(ref, () => ({
+    onKeyDown: (event: KeyboardEvent) => {
+      if (items.length === 0) return false;
+      if (event.key === "ArrowUp") {
+        setSelectedIndex((i) => (i + items.length - 1) % items.length);
+        return true;
+      }
+      if (event.key === "ArrowDown") {
+        setSelectedIndex((i) => (i + 1) % items.length);
+        return true;
+      }
+      if (event.key === "Enter") {
+        selectItem(selectedIndex);
+        return true;
+      }
+      return false;
+    },
+  }));
+
+  const rect = clientRect?.();
+  if (items.length === 0 || !rect) return null;
+
+  return (
+    <DropdownMenu open modal={false}>
+      <DropdownMenu.Trigger>
+        <span
+          style={{
+            position: "fixed",
+            top: rect.top,
+            left: rect.left,
+            width: 1,
+            height: rect.height,
+            opacity: 0,
+            pointerEvents: "none",
+          }}
+        />
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content
+        side="bottom"
+        align="start"
+        sideOffset={4}
+        preventAutoFocus
+      >
+        {items.map((item, index) => (
+          <DropdownMenu.ItemWithDescription
+            key={item.name}
+            label={`/${item.name}`}
+            description={item.description}
+            highlighted={index === selectedIndex}
+            onClick={() => selectItem(index)}
+          />
+        ))}
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/components/ConversationalAnalytics/MessageSegments.tsx
+++ b/frontend/src/components/ConversationalAnalytics/MessageSegments.tsx
@@ -1,0 +1,54 @@
+import { Fragment } from "react";
+import { Badge } from "src/components/design-system";
+import type { MessageSegment } from "src/components/ConversationalAnalytics/dto";
+
+function isMessageSegment(value: unknown): value is MessageSegment {
+  if (typeof value !== "object" || value === null) return false;
+  const segment = value as Record<string, unknown>;
+  if (segment.type === "TEXT") return typeof segment.text === "string";
+  if (segment.type === "COMMAND") return typeof segment.name === "string";
+  return false;
+}
+
+export function parseMessageSegments(content: string): MessageSegment[] | null {
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed) && parsed.every(isMessageSegment)) {
+      return parsed as MessageSegment[];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function segmentsToText(segments: MessageSegment[]): string {
+  return segments
+    .map((segment) =>
+      segment.type === "COMMAND" ? `/${segment.name}` : segment.text,
+    )
+    .join("");
+}
+
+type MessageSegmentsProps = {
+  segments: MessageSegment[];
+};
+
+export function MessageSegments({ segments }: MessageSegmentsProps) {
+  return (
+    <>
+      {segments.map((segment, i) =>
+        segment.type === "COMMAND" ? (
+          <Badge
+            key={`command-${i}`}
+            variant="command"
+            shape="rounded"
+            size="md"
+          >{`/${segment.name}`}</Badge>
+        ) : (
+          <Fragment key={`text-${i}`}>{segment.text}</Fragment>
+        ),
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/ConversationalAnalytics/NewConversationPanel/NewConversationPanel.tsx
+++ b/frontend/src/components/ConversationalAnalytics/NewConversationPanel/NewConversationPanel.tsx
@@ -6,6 +6,7 @@ import { useConnections } from "src/api/connection/queries";
 import { useAiConfiguration } from "src/api/ai_configuration";
 import { APP_ROUTES } from "src/constants/app_routes";
 import { MessageComposer, type MessageComposerHandle } from "src/components/ConversationalAnalytics/MessageComposer";
+import type { MessageSegment } from "src/api/conversational_analytics/queries";
 import { SuggestedQuestions } from "src/components/ConversationalAnalytics/NewConversationPanel/SuggestedQuestions";
 import styles from "./NewConversationPanel.module.css";
 
@@ -36,10 +37,10 @@ export function NewConversationPanel() {
       ? connectionDisabledTooltip
       : undefined;
 
-  const handleSubmit = (user_message: string) => {
+  const handleSubmit = (segments: MessageSegment[]) => {
     if (!selectedConnectionId) return;
     createConversation(
-      { connection_id: selectedConnectionId, user_message },
+      { connection_id: selectedConnectionId, segments },
       {
         onSuccess: (data) => {
           navigate(

--- a/frontend/src/components/ConversationalAnalytics/StreamingAgentTrace/StreamingAgentTrace.tsx
+++ b/frontend/src/components/ConversationalAnalytics/StreamingAgentTrace/StreamingAgentTrace.tsx
@@ -3,8 +3,10 @@ import { Flex, Box, ShimmeringText, Text } from "src/components/design-system";
 import {
   IN_PROGRESS_EVENTS,
   extractChartData,
+  extractCanvasGenerated,
   type AgentEvent,
 } from "src/components/ConversationalAnalytics/dto";
+import { CanvasGeneratedCard } from "src/components/ConversationalAnalytics/CanvasGeneratedCard";
 import {
   STEP_LABELS,
   TRACE_HIDDEN_EVENTS,
@@ -64,6 +66,7 @@ export function StreamingAgentTrace({
   const steps = useMemo(() => buildDisplaySteps(events), [events]);
   const statusText = useMemo(() => deriveStatusText(events), [events]);
   const chartData = useMemo(() => extractChartData(events), [events]);
+  const canvas = useMemo(() => extractCanvasGenerated(events), [events]);
   const routerDecision = useMemo(() => extractRouterDecision(events), [events]);
 
   if (steps.length === 0 && !isStreaming && !routerDecision) return null;
@@ -100,6 +103,7 @@ export function StreamingAgentTrace({
         />
       )}
       {chartData && <QueryResultChart chartData={chartData} />}
+      {canvas && <CanvasGeneratedCard data={canvas} />}
     </>
   );
 }

--- a/frontend/src/components/ConversationalAnalytics/dto.tsx
+++ b/frontend/src/components/ConversationalAnalytics/dto.tsx
@@ -1,13 +1,17 @@
 import { ChartType } from "src/components/Chart";
 import { ExecuteCellResponseDto } from "src/components/Notebook/Cell/dto";
 
+export type MessageSegment =
+  | { type: "TEXT"; text: string }
+  | { type: "COMMAND"; name: string };
+
 export type CreateConversationDto = {
   connection_id: string;
-  user_message: string;
+  segments: MessageSegment[];
 };
 
 export type AppendUserMessageDto = {
-  user_message: string;
+  segments: MessageSegment[];
 };
 
 export type ConversationDto = {
@@ -152,6 +156,8 @@ export const AgentEventName = {
   RecommendingVisualization: "recommending_visualization",
   RecommendedVisualization: "recommended_visualization",
   SuggestedFollowups: "suggested_followups",
+  GeneratingCanvas: "generating_canvas",
+  CanvasGenerated: "canvas_generated",
 } as const;
 
 export type AgentEventName =
@@ -168,6 +174,7 @@ export const IN_PROGRESS_EVENTS = new Set<string>([
   AgentEventName.GeneratingSql,
   AgentEventName.ExecutingQuery,
   AgentEventName.RecommendingVisualization,
+  AgentEventName.GeneratingCanvas,
 ]);
 
 export type AgentEvent = {
@@ -220,6 +227,7 @@ export const RouterCode = {
   Clarify: "clarify",
   RejectOffTopic: "reject_off_topic",
   RejectUnsafe: "reject_unsafe",
+  GenerateCanvas: "generate_canvas",
 } as const;
 
 export type RouterCode = (typeof RouterCode)[keyof typeof RouterCode];
@@ -246,6 +254,15 @@ export type RecommendedVisualizationData = {
 
 export type SuggestedFollowupsData = {
   questions: string[];
+};
+
+export type CanvasGeneratedData = {
+  canvas_id: string;
+  name: string;
+  description: string | null;
+  sql_cell_count: number;
+  chart_cell_count: number;
+  dashboard_charts_count: number;
 };
 
 export type ChartRenderData = {
@@ -292,4 +309,13 @@ export function extractChartData(events: AgentEvent[]): ChartRenderData | null {
     queryData,
     visualization: vizData.visualization,
   };
+}
+
+export function extractCanvasGenerated(
+  events: AgentEvent[],
+): CanvasGeneratedData | null {
+  const event = events.find(
+    (e) => e.event_name === AgentEventName.CanvasGenerated,
+  );
+  return event?.data ? (event.data as CanvasGeneratedData) : null;
 }

--- a/frontend/src/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/components/Dashboard/Dashboard.tsx
@@ -9,6 +9,7 @@ import { DashboardToolbar } from "src/components/Dashboard/DashboardToolbar";
 import { ChartBrowser } from "src/components/Dashboard/ChartBrowser";
 import {
   convertDtoToRGLayout,
+  GRID_COLUMN_COUNT,
   DEFAULT_CHART_WIDTH,
   DEFAULT_CHART_HEIGHT,
 } from "src/components/Dashboard/dto";
@@ -134,7 +135,7 @@ export function Dashboard({ onNavigateToNotebook }: DashboardProps) {
       <ReactGridLayout
         className={`${styles.layout} ${isEditing ? styles.layoutEditing : ""}`}
         layout={layout}
-        cols={12}
+        cols={GRID_COLUMN_COUNT}
         rowHeight={100}
         margin={margin}
         containerPadding={containerPadding}

--- a/frontend/src/components/Dashboard/dto.tsx
+++ b/frontend/src/components/Dashboard/dto.tsx
@@ -1,5 +1,6 @@
 import { Layout } from "react-grid-layout";
 
+export const GRID_COLUMN_COUNT = 12;
 export const DEFAULT_CHART_WIDTH = 4;
 export const DEFAULT_CHART_HEIGHT = 3;
 

--- a/frontend/src/components/design-system/Badge/Badge.module.css
+++ b/frontend/src/components/design-system/Badge/Badge.module.css
@@ -2,12 +2,26 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--border-radius-full);
-  padding: var(--space-2xs) var(--space-xs);
   font-size: var(--font-size-xs);
   font-weight: var(--font-weight-medium);
   line-height: var(--line-height-tight);
   white-space: nowrap;
+}
+
+.sm {
+  padding: var(--space-2xs) var(--space-xs);
+}
+
+.md {
+  padding: var(--space-xs) var(--space-sm);
+}
+
+.pill {
+  border-radius: var(--border-radius-full);
+}
+
+.rounded {
+  border-radius: var(--border-radius-md);
 }
 
 .default {
@@ -33,4 +47,9 @@
 .yellow {
   background-color: var(--color-yellow-200);
   color: var(--color-yellow-900);
+}
+
+.command {
+  background-color: var(--color-primary-100);
+  color: var(--color-primary-600);
 }

--- a/frontend/src/components/design-system/Badge/Badge.tsx
+++ b/frontend/src/components/design-system/Badge/Badge.tsx
@@ -2,19 +2,29 @@ import classNames from "classnames";
 import styles from "src/components/design-system/Badge/Badge.module.css";
 
 export type BadgeProps = React.HTMLAttributes<HTMLElement> & {
-  variant?: "default" | "subtle" | "blue" | "green" | "yellow";
+  variant?: "default" | "subtle" | "blue" | "green" | "yellow" | "command";
+  shape?: "pill" | "rounded";
+  size?: "sm" | "md";
   children: string | number;
 };
 
 export function Badge({
   variant = "default",
+  shape = "pill",
+  size = "sm",
   className,
   children,
   ...restProps
 }: BadgeProps) {
   return (
     <span
-      className={classNames(styles.badge, styles[variant], className)}
+      className={classNames(
+        styles.badge,
+        styles[variant],
+        styles[shape],
+        styles[size],
+        className,
+      )}
       {...restProps}
     >
       {children}

--- a/frontend/src/components/design-system/Card/Card.tsx
+++ b/frontend/src/components/design-system/Card/Card.tsx
@@ -14,6 +14,7 @@ type CardRootProps = {
   className?: string;
   variant?: CardVariant;
   onClick?: () => void;
+  sx?: React.CSSProperties;
 };
 
 type CardContextType = {
@@ -22,7 +23,13 @@ type CardContextType = {
 
 const CardContext = createContext<CardContextType | null>(null);
 
-const CardRoot = ({ children, className, variant, onClick }: CardRootProps) => {
+const CardRoot = ({
+  children,
+  className,
+  variant,
+  onClick,
+  sx,
+}: CardRootProps) => {
   const contextValue = {
     variant: variant,
   };
@@ -36,7 +43,7 @@ const CardRoot = ({ children, className, variant, onClick }: CardRootProps) => {
           duration: Duration.FAST,
           ease: EASE,
         }}
-        sx={{ cursor: "pointer" }}
+        sx={{ cursor: "pointer", ...sx }}
         className={className}
         backgroundColor="default"
         border="default"

--- a/frontend/src/components/design-system/DropdownMenu/DropdownMenu.module.css
+++ b/frontend/src/components/design-system/DropdownMenu/DropdownMenu.module.css
@@ -38,3 +38,40 @@
   align-items: center;
   gap: var(--space-md);
 }
+
+.itemWithDescription {
+  all: unset;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3xs);
+  padding: var(--space-xs);
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  user-select: none;
+}
+
+.itemWithDescription:hover,
+.itemWithDescription[data-highlighted],
+.itemWithDescription.highlighted {
+  background-color: var(--color-grey-200);
+  outline: none;
+}
+
+.itemWithDescription[data-disabled] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.itemLabel {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+}
+
+.itemDescription {
+  font-size: var(--font-size-xs);
+  color: var(--color-grey-600);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/frontend/src/components/design-system/DropdownMenu/DropdownMenu.tsx
+++ b/frontend/src/components/design-system/DropdownMenu/DropdownMenu.tsx
@@ -1,4 +1,5 @@
 import * as RadixDropdownMenu from "@radix-ui/react-dropdown-menu";
+import classNames from "classnames";
 import { ReactNode } from "react";
 import { IconType } from "src/components/design-system/datatypes";
 import { Icon } from "src/components/design-system/Icon";
@@ -48,6 +49,7 @@ type DropdownMenuContentProps = {
   side?: "top" | "right" | "bottom" | "left";
   sideOffset?: number;
   alignOffset?: number;
+  preventAutoFocus?: boolean;
 };
 
 function DropdownMenuContent({
@@ -56,7 +58,14 @@ function DropdownMenuContent({
   side = "bottom",
   sideOffset = 5,
   alignOffset,
+  preventAutoFocus = false,
 }: DropdownMenuContentProps) {
+  const autoFocusProps = preventAutoFocus
+    ? {
+        onOpenAutoFocus: (event: Event) => event.preventDefault(),
+        onCloseAutoFocus: (event: Event) => event.preventDefault(),
+      }
+    : {};
   return (
     <RadixDropdownMenu.Portal>
       <RadixDropdownMenu.Content
@@ -65,6 +74,7 @@ function DropdownMenuContent({
         side={side}
         sideOffset={sideOffset}
         alignOffset={alignOffset}
+        {...autoFocusProps}
       >
         {children}
       </RadixDropdownMenu.Content>
@@ -97,8 +107,38 @@ function DropdownMenuItemComponent({
   );
 }
 
+type DropdownMenuItemWithDescriptionProps = {
+  label: string;
+  description: string;
+  onClick: () => void;
+  highlighted?: boolean;
+  disabled?: boolean;
+};
+
+function DropdownMenuItemWithDescriptionComponent({
+  label,
+  description,
+  onClick,
+  highlighted,
+  disabled,
+}: DropdownMenuItemWithDescriptionProps) {
+  return (
+    <RadixDropdownMenu.Item
+      className={classNames(styles.itemWithDescription, {
+        [styles.highlighted]: highlighted,
+      })}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      <span className={styles.itemLabel}>{label}</span>
+      <span className={styles.itemDescription}>{description}</span>
+    </RadixDropdownMenu.Item>
+  );
+}
+
 export const DropdownMenu = Object.assign(DropdownMenuRoot, {
   Trigger: DropdownMenuTrigger,
   Content: DropdownMenuContent,
   Item: DropdownMenuItemComponent,
+  ItemWithDescription: DropdownMenuItemWithDescriptionComponent,
 });


### PR DESCRIPTION
## Summary

Adds slash commands to the conversational analytics composer, with `/canvas` as the first command: it takes the conversation so far and generates a Canvas — a notebook of SQL cells, chart cells, and a laid-out dashboard.

Closes #119

## Changes

**Backend**
- New `canvas_generation_agent` that plans the canvas from conversation history: cell titles, SQL, chart specs and dashboard sizing.
- New `conversational_analytics/command` module and message `segment` model, so a message carries structured segments (text + command) instead of a raw string.
- `RouterCode::GenerateCanvas` routes a `/canvas` message to the generation agent.
- `canvas::service::generate_canvas_from_plan` creates the cells and dashboard layout from the plan.
- `DashboardGridPacker` (`dashboard::service`) packs charts left-to-right across the 12-column grid, wrapping rows and clamping each chart to the grid bounds. Grid geometry now lives in `dashboard::constants`.

**Frontend**
- Slash command menu, inline command badge and segment rendering in the message composer (uses `@tiptap/suggestion`).
- `CanvasGeneratedCard` shows the generated canvas with cell/chart counts and links through to it.
- Design system: `Badge` variants, `DropdownMenu` additions, and `Card` now forwards an `sx` prop.

## Notes

- Chart cell content is written by serializing the real `cell::dto::ChartContent`, so the stored shape matches what the chart editor reads/writes rather than being hand-rolled JSON. SQL cells store raw SQL text.
- Charts always get an `aggregate_function` — chart execution hard-fails without one — defaulting to `MAX` if the planner omits it.
- The generation prompt is instructed to vary chart widths so the dashboard fills rows instead of stacking full-width charts.

## Testing

- `cargo check` clean; `npx tsc --noEmit` clean.
- Manually exercised: run `/canvas` in a conversation, open the generated canvas, confirm SQL cells run, chart cells render, and the dashboard is laid out in rows.