### PR TITLE
feat(artifacts): add artifacts button and panel to conversations

### DIFF
--- a/frontend/src/components/ConversationalAnalytics/Artifacts/ArtifactsButton.tsx
+++ b/frontend/src/components/ConversationalAnalytics/Artifacts/ArtifactsButton.tsx
@@ -1,0 +1,20 @@
+import { IconButton } from "src/components/design-system";
+import { useArtifacts } from "src/components/ConversationalAnalytics/Artifacts/ArtifactsContext";
+
+const ARTIFACTS_TOOLTIP = { text: "Artifacts" };
+
+export const ArtifactsButton = () => {
+  const { artifacts, togglePanel } = useArtifacts();
+
+  if (artifacts.length === 0) return null;
+
+  return (
+    <IconButton
+      type="layers"
+      backgroundColor="default"
+      iconColor="grey"
+      tooltip={ARTIFACTS_TOOLTIP}
+      onClick={togglePanel}
+    />
+  );
+};

--- a/frontend/src/components/ConversationalAnalytics/Artifacts/ArtifactsContext.tsx
+++ b/frontend/src/components/ConversationalAnalytics/Artifacts/ArtifactsContext.tsx
@@ -1,0 +1,45 @@
+import { createContext, useCallback, useContext, useState } from "react";
+import { useConversationArtifacts } from "src/components/ConversationalAnalytics/Artifacts/useConversationArtifacts";
+import type { Artifact } from "src/components/ConversationalAnalytics/dto";
+
+type ArtifactsContextValue = {
+  artifacts: Artifact[];
+  isPanelOpen: boolean;
+  togglePanel: () => void;
+  closePanel: () => void;
+};
+
+const ArtifactsContext = createContext<ArtifactsContextValue | null>(null);
+
+type ArtifactsProviderProps = {
+  conversationId: string;
+  children: React.ReactNode;
+};
+
+export const ArtifactsProvider = ({
+  conversationId,
+  children,
+}: ArtifactsProviderProps) => {
+  const artifacts = useConversationArtifacts(conversationId);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const togglePanel = useCallback(() => setIsOpen((open) => !open), []);
+  const closePanel = useCallback(() => setIsOpen(false), []);
+
+  const value: ArtifactsContextValue = {
+    artifacts,
+    isPanelOpen: isOpen && artifacts.length > 0,
+    togglePanel,
+    closePanel,
+  };
+
+  return <ArtifactsContext value={value}>{children}</ArtifactsContext>;
+};
+
+export const useArtifacts = (): ArtifactsContextValue => {
+  const context = useContext(ArtifactsContext);
+  if (!context) {
+    throw new Error("useArtifacts must be used within ArtifactsProvider");
+  }
+  return context;
+};

--- a/frontend/src/components/ConversationalAnalytics/Artifacts/ArtifactsPanel.tsx
+++ b/frontend/src/components/ConversationalAnalytics/Artifacts/ArtifactsPanel.tsx
@@ -1,0 +1,82 @@
+import {
+  Flex,
+  IconButton,
+  MotionFlex,
+  Text,
+} from "src/components/design-system";
+import { Duration, EASE } from "src/components/design-system/animation";
+import { CanvasGeneratedCard } from "src/components/ConversationalAnalytics/CanvasGeneratedCard";
+import { useArtifacts } from "src/components/ConversationalAnalytics/Artifacts/ArtifactsContext";
+import {
+  ArtifactType,
+  type Artifact,
+} from "src/components/ConversationalAnalytics/dto";
+
+const PANEL_STYLE = { flexShrink: 0 };
+const PANEL_INITIAL = { x: 16, opacity: 0 };
+const PANEL_ANIMATE = { x: 0, opacity: 1 };
+const PANEL_TRANSITION = { duration: Duration.FAST, ease: EASE };
+const CLOSE_TOOLTIP = { text: "Close artifacts" };
+
+const renderArtifact = (artifact: Artifact) => {
+  switch (artifact.type) {
+    case ArtifactType.Canvas:
+      return <CanvasGeneratedCard data={artifact.data} />;
+    default:
+      return null;
+  }
+};
+
+export const ArtifactsPanel = () => {
+  const { artifacts, isPanelOpen, closePanel } = useArtifacts();
+
+  if (!isPanelOpen) return null;
+
+  return (
+    <MotionFlex
+      as="aside"
+      aria-label="Artifacts"
+      direction="column"
+      height="100%"
+      width="22rem"
+      borderLeft="divider"
+      marginLeft="lg"
+      paddingLeft="lg"
+      paddingRight="sm"
+      paddingTop="lg"
+      paddingBottom="lg"
+      gap="md"
+      sx={PANEL_STYLE}
+      initial={PANEL_INITIAL}
+      animate={PANEL_ANIMATE}
+      transition={PANEL_TRANSITION}
+    >
+      <Flex alignItems="center" justifyContent="space-between">
+        <Text fontSize="lg" color="darkGrey">
+          {`Artifacts (${artifacts.length})`}
+        </Text>
+        <IconButton
+          type="close"
+          backgroundColor="default"
+          iconColor="grey"
+          tooltip={CLOSE_TOOLTIP}
+          onClick={closePanel}
+        />
+      </Flex>
+      <Flex
+        direction="column"
+        gap="md"
+        flex="grow"
+        overflow="scrollY"
+        paddingTop="sm"
+        paddingRight="md"
+      >
+        {artifacts.map((artifact) => (
+          <Flex key={artifact.id} direction="column">
+            {renderArtifact(artifact)}
+          </Flex>
+        ))}
+      </Flex>
+    </MotionFlex>
+  );
+};

--- a/frontend/src/components/ConversationalAnalytics/Artifacts/index.tsx
+++ b/frontend/src/components/ConversationalAnalytics/Artifacts/index.tsx
@@ -1,0 +1,3 @@
+export { ArtifactsProvider } from "src/components/ConversationalAnalytics/Artifacts/ArtifactsContext";
+export { ArtifactsButton } from "src/components/ConversationalAnalytics/Artifacts/ArtifactsButton";
+export { ArtifactsPanel } from "src/components/ConversationalAnalytics/Artifacts/ArtifactsPanel";

--- a/frontend/src/components/ConversationalAnalytics/Artifacts/useConversationArtifacts.ts
+++ b/frontend/src/components/ConversationalAnalytics/Artifacts/useConversationArtifacts.ts
@@ -1,0 +1,42 @@
+import { useMemo, useRef } from "react";
+import { useConversation } from "src/api/conversational_analytics";
+import { useConversationStream } from "src/components/ConversationalAnalytics/ConversationStreamContext";
+import {
+  extractArtifactsFromEvents,
+  extractArtifactsFromMessages,
+  type Artifact,
+} from "src/components/ConversationalAnalytics/dto";
+
+type ArtifactCache = {
+  conversationId: string;
+  artifacts: Map<string, Artifact>;
+};
+
+export function useConversationArtifacts(conversationId: string): Artifact[] {
+  const { data } = useConversation(conversationId);
+  const { events } = useConversationStream(conversationId);
+  const cacheRef = useRef<ArtifactCache>({
+    conversationId,
+    artifacts: new Map(),
+  });
+
+  return useMemo(() => {
+    const cache = cacheRef.current;
+    if (cache.conversationId !== conversationId) {
+      cache.conversationId = conversationId;
+      cache.artifacts = new Map();
+    }
+
+    const seen = [
+      ...extractArtifactsFromMessages(data?.messages ?? []),
+      ...extractArtifactsFromEvents(events),
+    ];
+    for (const artifact of seen) {
+      if (!cache.artifacts.has(artifact.id)) {
+        cache.artifacts.set(artifact.id, artifact);
+      }
+    }
+
+    return [...cache.artifacts.values()];
+  }, [conversationId, data?.messages, events]);
+}

--- a/frontend/src/components/ConversationalAnalytics/CanvasGeneratedCard.tsx
+++ b/frontend/src/components/ConversationalAnalytics/CanvasGeneratedCard.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useMemo } from "react";
 import { Link, useNavigate } from "react-router";
-import { Card, Flex, Badge, Icon, ToolTip, Text } from "src/components/design-system";
+import {
+  Card,
+  Flex,
+  Badge,
+  Icon,
+  ToolTip,
+  Text,
+} from "src/components/design-system";
 import type { IconType } from "src/components/design-system/datatypes";
 import { APP_ROUTES } from "src/constants/app_routes";
 import type { CanvasGeneratedData } from "src/components/ConversationalAnalytics/dto";
@@ -28,12 +35,14 @@ type CanvasGeneratedCardProps = {
 
 const LINK_STYLE = { color: "inherit", textDecoration: "none" };
 const CARD_STYLE = { transformOrigin: "left center" };
+const BADGE_STYLE = { flexShrink: 0 };
+const STATS_STYLE = { flexWrap: "wrap" } as const;
 
 export function CanvasGeneratedCard({ data }: CanvasGeneratedCardProps) {
   const navigate = useNavigate();
   const canvasPath = useMemo(
     () => APP_ROUTES.CANVAS.replace(":id", data.canvas_id),
-    [data.canvas_id]
+    [data.canvas_id],
   );
 
   const handleClick = useCallback(() => {
@@ -48,13 +57,23 @@ export function CanvasGeneratedCard({ data }: CanvasGeneratedCardProps) {
   return (
     <Card onClick={handleClick} sx={CARD_STYLE}>
       <Card.Header baseAccessbilityLevel={2}>
-        <Link to={canvasPath} style={LINK_STYLE} onClick={handleLinkClick}>
-          <Card.Title>{data.name}</Card.Title>
-        </Link>
+        <Flex
+          gap="md"
+          width="100%"
+          alignItems="flex-start"
+          justifyContent="space-between"
+        >
+          <Link to={canvasPath} style={LINK_STYLE} onClick={handleLinkClick}>
+            <Card.Title>{data.name}</Card.Title>
+          </Link>
+          <Badge variant="green" shape="rounded" style={BADGE_STYLE}>
+            Canvas
+          </Badge>
+        </Flex>
         <Card.Description>{data.description}</Card.Description>
       </Card.Header>
       <Card.Content>
-        <Flex gap="lg" alignItems="center" sx={{ flexWrap: "wrap" }}>
+        <Flex gap="lg" alignItems="center" sx={STATS_STYLE}>
           <CanvasStat
             iconType="table"
             count={data.sql_cell_count}

--- a/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/ExistingConversationPanel.tsx
+++ b/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/ExistingConversationPanel.tsx
@@ -25,12 +25,20 @@ import {
 import type { MessageComposerHandle } from "src/components/ConversationalAnalytics/MessageComposer";
 import type { MessageSegment } from "src/api/conversational_analytics/queries";
 import { extractFollowUpQuestions } from "src/components/ConversationalAnalytics/dto";
+import {
+  ArtifactsButton,
+  ArtifactsPanel,
+  ArtifactsProvider,
+} from "src/components/ConversationalAnalytics/Artifacts";
 import { SuggestedQuestionList } from "src/components/ConversationalAnalytics/SuggestedQuestionList";
 import {
   MessageSegments,
   parseMessageSegments,
   segmentsToText,
 } from "src/components/ConversationalAnalytics/MessageSegments";
+
+const MIN_WIDTH_STYLE = { minWidth: 0 };
+const FLEX_SHRINK_STYLE = { flexShrink: 0 };
 
 type MessageProps = {
   connectionId: string;
@@ -153,58 +161,76 @@ export const ExistingConversationPanel = () => {
   const conversation = conversationQuery.data?.conversation;
 
   return (
-    <Flex direction="column" height="100%" width="100%">
-      <Flex direction="column" flex="grow" overflow="scrollY" paddingTop="lg">
-        {conversation && (
-          <Flex paddingBottom="md" alignItems="center" width="100%">
-            <ConversationActionsMenu conversation={conversation}>
-              <button
-                type="button"
-                className={styles.conversationHeaderTrigger}
-                aria-label="Conversation actions"
-              >
-                <Flex flex="grow" alignItems="center" sx={{ minWidth: 0 }}>
-                  <Text truncate fontSize="lg" color="darkGrey">
-                    {conversation.name}
-                  </Text>
-                </Flex>
-                <Icon type="chevron_down" color="grey" size="md" />
-              </button>
-            </ConversationActionsMenu>
-          </Flex>
-        )}
-        <Flex direction="column" className={styles.messageColumn}>
-          {renderMessages()}
-          {(isStreaming || streamingEvents.length > 0) && (
-            <Flex direction="column" className={styles.messageWrapper}>
-              <StreamingAgentTrace
-                events={streamingEvents}
-                isStreaming={isStreaming}
-              />
+    <ArtifactsProvider conversationId={conversationId}>
+      <Flex direction="row" height="100%" width="100%">
+        <Flex direction="column" flex="grow" height="100%" sx={MIN_WIDTH_STYLE}>
+          {conversation && (
+            <Flex
+              paddingTop="lg"
+              paddingBottom="md"
+              alignItems="center"
+              justifyContent="space-between"
+              gap="sm"
+              width="100%"
+              shadow="scroll"
+              sx={FLEX_SHRINK_STYLE}
+            >
+              <ConversationActionsMenu conversation={conversation}>
+                <button
+                  type="button"
+                  className={styles.conversationHeaderTrigger}
+                  aria-label="Conversation actions"
+                >
+                  <Flex flex="grow" alignItems="center" sx={MIN_WIDTH_STYLE}>
+                    <Text truncate fontSize="lg" color="darkGrey">
+                      {conversation.name}
+                    </Text>
+                  </Flex>
+                  <Icon type="chevron_down" color="grey" size="md" />
+                </button>
+              </ConversationActionsMenu>
+              <ArtifactsButton />
             </Flex>
           )}
-          {gate.canSend && !isStreaming && followUpQuestions.length > 0 && (
-            <SuggestedQuestionList
-              questions={followUpQuestions.map((text) => ({ id: text, text }))}
-              onPick={(text) => composerRef.current?.setText(text)}
+          <Flex direction="column" flex="grow" overflow="scrollY">
+            <Flex direction="column" className={styles.messageColumn}>
+              {renderMessages()}
+              {(isStreaming || streamingEvents.length > 0) && (
+                <Flex direction="column" className={styles.messageWrapper}>
+                  <StreamingAgentTrace
+                    events={streamingEvents}
+                    isStreaming={isStreaming}
+                  />
+                </Flex>
+              )}
+              {gate.canSend && !isStreaming && followUpQuestions.length > 0 && (
+                <SuggestedQuestionList
+                  questions={followUpQuestions.map((text) => ({
+                    id: text,
+                    text,
+                  }))}
+                  onPick={(text) => composerRef.current?.setText(text)}
+                />
+              )}
+            </Flex>
+          </Flex>
+          <Flex
+            direction="column"
+            paddingTop="md"
+            paddingBottom="md"
+            sx={FLEX_SHRINK_STYLE}
+          >
+            <MessageComposer
+              ref={composerRef}
+              placeholder={composerPlaceholder}
+              onSubmit={handleSubmit}
+              disabled={composerDisabled}
+              disabledTooltip={composerDisabledTooltip}
             />
-          )}
+          </Flex>
         </Flex>
+        <ArtifactsPanel />
       </Flex>
-      <Flex
-        direction="column"
-        paddingTop="md"
-        paddingBottom="md"
-        sx={{ flexShrink: 0 }}
-      >
-        <MessageComposer
-          ref={composerRef}
-          placeholder={composerPlaceholder}
-          onSubmit={handleSubmit}
-          disabled={composerDisabled}
-          disabledTooltip={composerDisabledTooltip}
-        />
-      </Flex>
-    </Flex>
+    </ArtifactsProvider>
   );
 };

--- a/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/useCanSendFollowUp.ts
+++ b/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/useCanSendFollowUp.ts
@@ -1,7 +1,4 @@
-import {
-  Sender,
-  useConversation,
-} from "src/api/conversational_analytics";
+import { Sender, useConversation } from "src/api/conversational_analytics";
 import { useAiConfiguration } from "src/api/ai_configuration";
 import { useConversationStream } from "src/components/ConversationalAnalytics/ConversationStreamContext";
 

--- a/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandBadge.tsx
+++ b/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandBadge.tsx
@@ -5,7 +5,11 @@ export function SlashCommandBadge({ node }: NodeViewProps) {
   const commandName = node.attrs.commandName as string;
   return (
     <NodeViewWrapper as="span" contentEditable={false}>
-      <Badge variant="command" shape="rounded" size="sm">{`/${commandName}`}</Badge>
+      <Badge
+        variant="command"
+        shape="rounded"
+        size="sm"
+      >{`/${commandName}`}</Badge>
     </NodeViewWrapper>
   );
 }

--- a/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandList.tsx
+++ b/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandList.tsx
@@ -1,9 +1,4 @@
-import {
-  useEffect,
-  useImperativeHandle,
-  useState,
-  type Ref,
-} from "react";
+import { useEffect, useImperativeHandle, useState, type Ref } from "react";
 import { DropdownMenu } from "src/components/design-system";
 import type { SlashCommand } from "./SlashCommandExtension";
 

--- a/frontend/src/components/ConversationalAnalytics/NewConversationPanel/NewConversationPanel.tsx
+++ b/frontend/src/components/ConversationalAnalytics/NewConversationPanel/NewConversationPanel.tsx
@@ -5,7 +5,10 @@ import { useCreateConversation } from "src/api/conversational_analytics/queries"
 import { useConnections } from "src/api/connection/queries";
 import { useAiConfiguration } from "src/api/ai_configuration";
 import { APP_ROUTES } from "src/constants/app_routes";
-import { MessageComposer, type MessageComposerHandle } from "src/components/ConversationalAnalytics/MessageComposer";
+import {
+  MessageComposer,
+  type MessageComposerHandle,
+} from "src/components/ConversationalAnalytics/MessageComposer";
 import type { MessageSegment } from "src/api/conversational_analytics/queries";
 import { SuggestedQuestions } from "src/components/ConversationalAnalytics/NewConversationPanel/SuggestedQuestions";
 import styles from "./NewConversationPanel.module.css";
@@ -28,8 +31,7 @@ export function NewConversationPanel() {
   const isAiReady = aiConfiguration?.status === "live";
   const disabled = !isAiReady || !selectedConnectionId || isPending;
 
-  const aiDisabledTooltip =
-    "Configure AI provider in Settings";
+  const aiDisabledTooltip = "Configure AI provider in Settings";
   const connectionDisabledTooltip = "Select a connection to start.";
   const disabledTooltip = !isAiReady
     ? aiDisabledTooltip

--- a/frontend/src/components/ConversationalAnalytics/QueryResultChart/index.tsx
+++ b/frontend/src/components/ConversationalAnalytics/QueryResultChart/index.tsx
@@ -1,1 +1,4 @@
-export { QueryResultChart, QueryResultChartContainer } from "./QueryResultChart";
+export {
+  QueryResultChart,
+  QueryResultChartContainer,
+} from "./QueryResultChart";

--- a/frontend/src/components/ConversationalAnalytics/dto.tsx
+++ b/frontend/src/components/ConversationalAnalytics/dto.tsx
@@ -49,8 +49,7 @@ export const MessageStatus = {
   Rejected: "REJECTED",
 } as const;
 
-export type MessageStatus =
-  (typeof MessageStatus)[keyof typeof MessageStatus];
+export type MessageStatus = (typeof MessageStatus)[keyof typeof MessageStatus];
 
 export type ConversationMessageDto = {
   id: string;
@@ -265,6 +264,18 @@ export type CanvasGeneratedData = {
   dashboard_charts_count: number;
 };
 
+export const ArtifactType = {
+  Canvas: "CANVAS",
+} as const;
+
+export type ArtifactType = (typeof ArtifactType)[keyof typeof ArtifactType];
+
+export type Artifact = {
+  id: string;
+  type: typeof ArtifactType.Canvas;
+  data: CanvasGeneratedData;
+};
+
 export type ChartRenderData = {
   queryData: ExecuteCellResponseDto;
   visualization: RecommendedVisualizationData["visualization"];
@@ -318,4 +329,42 @@ export function extractCanvasGenerated(
     (e) => e.event_name === AgentEventName.CanvasGenerated,
   );
   return event?.data ? (event.data as CanvasGeneratedData) : null;
+}
+
+function toCanvasArtifact(
+  data: CanvasGeneratedData | undefined,
+): Artifact | null {
+  if (!data?.canvas_id) return null;
+  return { id: data.canvas_id, type: ArtifactType.Canvas, data };
+}
+
+function toArtifact(event: AgentEvent): Artifact | null {
+  if (event.event_name !== AgentEventName.CanvasGenerated) return null;
+  return toCanvasArtifact(event.data as CanvasGeneratedData | undefined);
+}
+
+export function extractArtifactsFromEvents(events: AgentEvent[]): Artifact[] {
+  return events
+    .map(toArtifact)
+    .filter((artifact): artifact is Artifact => artifact !== null);
+}
+
+export function extractArtifactsFromMessages(
+  messages: ConversationMessageDto[],
+): Artifact[] {
+  const artifacts: Artifact[] = [];
+
+  for (const message of messages) {
+    if (message.sender !== Sender.Assistant) continue;
+    for (const content of message.content) {
+      try {
+        const artifact = toArtifact(JSON.parse(content.content) as AgentEvent);
+        if (artifact) artifacts.push(artifact);
+      } catch {
+        /* ignore unparseable content */
+      }
+    }
+  }
+
+  return artifacts;
 }

--- a/frontend/src/components/design-system/datatypes.tsx
+++ b/frontend/src/components/design-system/datatypes.tsx
@@ -127,7 +127,7 @@ export type ColorVariant =
 
 export type BorderVariant = "default" | "divider";
 
-export type ShadowVariant = "2xs" | "xs" | "sm" | "md" | "lg" | "xl";
+export type ShadowVariant = "2xs" | "xs" | "sm" | "md" | "lg" | "xl" | "scroll";
 
 export type Postition = "sticky" | "absolute" | "relative" | "fixed";
 

--- a/frontend/src/components/design-system/utils.tsx
+++ b/frontend/src/components/design-system/utils.tsx
@@ -226,6 +226,7 @@ function getShadowStyles(
     md: "var(--shadow-md)",
     lg: "var(--shadow-lg)",
     xl: "var(--shadow-xl)",
+    scroll: "var(--shadow-scroll)",
   };
 
   const shadowValue = shadowMapping[shadow];

--- a/frontend/src/css/index.css
+++ b/frontend/src/css/index.css
@@ -364,6 +364,8 @@ button {
     0 5px 10px hsla(0, 0%, 0%, 0.05), 0 15px 25px hsla(0, 0%, 0%, 0.15);
   --shadow-xl: 0 20px 40px hsla(0, 0%, 0%, 0.2);
 
+  --shadow-scroll: 0 6px 6px -6px hsla(0, 0%, 0%, 0.18);
+
   --shadow-primary-inset: inset 0 1px 0 var(--color-primary-100);
   --shadow-green-inset: inset 0 1px 0 var(--color-green-300);
 


### PR DESCRIPTION
## Summary

Surfaces the artifacts a conversation has produced. An artifacts button sits at the right end of the conversation header and opens a panel on the right listing them. Today the only artifact type is a generated canvas.

Closes #128

## Context

Each `canvas_generated` agent event is already persisted as a row in the assistant message's `content[]` and returned by `GET /conversations/:id`, so the artifact list is a projection of data the client already has. **No backend changes and no new endpoint.** The extension point for future artifact types (files, images) is the `Artifact` union and the `useConversationArtifacts` hook, not the transport.

## Changes

**Data layer** (`dto.tsx`)
- `ArtifactType` / `Artifact` discriminated union — one member today, adding a type means adding a member and a `switch` case
- `extractArtifactsFromMessages` and `extractArtifactsFromEvents` over a shared mapper, since the same event arrives unparsed from saved messages and parsed from the stream

**`Artifacts/`** (new)
- `ArtifactsContext` owns the artifact list and panel open state, so the parent needs no artifact state
- `ArtifactsButton` renders nothing when there are no artifacts
- `ArtifactsPanel` reuses `CanvasGeneratedCard` untouched, so a canvas looks identical in the thread and in the panel — and clicking through to the canvas needs no new code
- `useConversationArtifacts` merges saved messages with in-flight stream events, so the button appears the moment a canvas is generated

**`ExistingConversationPanel`**
- Restructured into a row: conversation column + panel
- Header pinned out of the scroll container so the title and button stay visible

**`CanvasGeneratedCard`** — green "Canvas" badge in line with the title. The design system's existing `green` variant is already light background / dark green text, so `Badge` itself is unchanged.

**Design system** — new `scroll` shadow variant (`--shadow-scroll`) for the pinned header. Existing shadow tokens have zero spread and bleed on all sides; this one pulls the spread back by the full blur radius so it reads as a scroll shadow.

## Screenshots

_To be added._

## Breaking changes

None.

## Testing

Per project convention, no tests added. Verified with `tsc --noEmit`, `eslint` (0 errors), and `vite build`.

## Note for reviewers

Five files carry Prettier-only reflows picked up by a directory-wide format: `useCanSendFollowUp.ts`, `SlashCommandBadge.tsx`, `SlashCommandList.tsx`, `NewConversationPanel.tsx`, `QueryResultChart/index.tsx`. Import/export wrapping only, no logic changes.