### PR TITLE
feat(search): add conversations to global search

### DIFF
--- a/backend/src/conversational_analytics/conversation/service.rs
+++ b/backend/src/conversational_analytics/conversation/service.rs
@@ -166,6 +166,16 @@ pub async fn list_conversations(
     })
 }
 
+pub async fn search_conversations_by_name(
+    app_state: &AppState,
+    search_query: Option<&str>,
+    limit: u64,
+) -> Result<Vec<entity::conversation::Model>, sea_orm::DbErr> {
+    repository::list_conversations(&app_state.database_connection, search_query, 0, limit)
+        .await
+        .map(|(conversations, _)| conversations)
+}
+
 /// Sequence number of conversation messages start from `1` not `0`
 pub async fn create_conversation(
     app_state: AppState,

--- a/backend/src/notebook/repository.rs
+++ b/backend/src/notebook/repository.rs
@@ -32,6 +32,20 @@ pub async fn get_notebook(db: &DatabaseConnection, id: Uuid) -> Result<notebook:
     }
 }
 
+pub async fn get_notebooks_by_ids(
+    db: &DatabaseConnection,
+    ids: Vec<Uuid>,
+) -> Result<Vec<notebook::Model>, DbErr> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let notebooks = notebook::Entity::find()
+        .filter(notebook::Column::Id.is_in(ids))
+        .all(db)
+        .await?;
+    Ok(notebooks)
+}
+
 pub async fn get_all_notebooks(db: &DatabaseConnection) -> Result<Vec<notebook::Model>, DbErr> {
     let notebooks = notebook::Entity::find().all(db).await?;
     Ok(notebooks)

--- a/backend/src/notebook/service.rs
+++ b/backend/src/notebook/service.rs
@@ -9,6 +9,7 @@ use axum::extract::Query;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use sea_orm::DatabaseTransaction;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 pub async fn does_notebook_exist(app_state: &AppState, id: Uuid) -> bool {
@@ -197,6 +198,18 @@ pub async fn get_notebook_by_canvas_id(
     canvas_id: Uuid,
 ) -> Result<entity::notebook::Model, sea_orm::DbErr> {
     repository::get_notebook_by_canvas_id(&app_state.database_connection, canvas_id).await
+}
+
+pub async fn get_canvas_ids_by_notebook_ids(
+    app_state: &AppState,
+    notebook_ids: Vec<Uuid>,
+) -> Result<HashMap<Uuid, Uuid>, sea_orm::DbErr> {
+    let notebooks =
+        repository::get_notebooks_by_ids(&app_state.database_connection, notebook_ids).await?;
+    Ok(notebooks
+        .into_iter()
+        .map(|notebook| (notebook.id, notebook.canvas_id))
+        .collect())
 }
 
 pub async fn get_notebook_transaction(

--- a/backend/src/search/constants.rs
+++ b/backend/src/search/constants.rs
@@ -3,6 +3,7 @@ pub enum EntityType {
     Canvas,
     SqlCell,
     ChartCell,
+    Conversation,
 }
 
 impl EntityType {
@@ -11,6 +12,7 @@ impl EntityType {
             EntityType::Canvas => "canvas",
             EntityType::SqlCell => "sql_cells",
             EntityType::ChartCell => "chart_cells",
+            EntityType::Conversation => "conversations",
         }
     }
 }

--- a/backend/src/search/dto.rs
+++ b/backend/src/search/dto.rs
@@ -78,4 +78,5 @@ pub struct SearchResultItemDto {
     pub name: Option<String>,
     pub entity_type: String,
     pub updated_at: DateTime<FixedOffset>,
+    pub canvas_id: Option<Uuid>,
 }

--- a/backend/src/search/service.rs
+++ b/backend/src/search/service.rs
@@ -2,10 +2,20 @@ use crate::canvas::service as canvas_service;
 use crate::cell::constants::CellType;
 use crate::cell::service as cell_service;
 use crate::common::AppState;
+use crate::conversational_analytics::conversation::service as conversation_service;
+use crate::notebook::service as notebook_service;
 use crate::search::constants::{EntityType, SEARCH_LIMIT_PER_ENTITY};
 use crate::search::dto::{SearchRequestDto, SearchResultItemDto};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
+use uuid::Uuid;
+
+const SUPPORTED_ENTITY_TYPES: [EntityType; 4] = [
+    EntityType::Canvas,
+    EntityType::SqlCell,
+    EntityType::ChartCell,
+    EntityType::Conversation,
+];
 
 async fn search_canvases(
     app_state: &AppState,
@@ -18,140 +28,141 @@ async fn search_canvases(
         canvas_service::search_canvases_by_name(app_state, search_query, limit).await?
     };
 
-    let mut results = Vec::new();
-    for canvas in canvases {
-        results.push(SearchResultItemDto {
+    Ok(canvases
+        .into_iter()
+        .map(|canvas| SearchResultItemDto {
             id: canvas.id,
             name: Some(canvas.name),
             entity_type: EntityType::Canvas.as_str().to_string(),
             updated_at: canvas.updated_at,
-        });
-    }
-
-    Ok(results)
+            canvas_id: None,
+        })
+        .collect())
 }
 
-async fn search_sql_cells(
+async fn search_conversations(
     app_state: &AppState,
     search_query: &str,
     limit: u64,
 ) -> Result<Vec<SearchResultItemDto>, sea_orm::DbErr> {
-    let cells = if search_query.is_empty() {
-        cell_service::get_last_modified_cells_by_type(app_state, CellType::Sql, limit).await?
-    } else {
-        cell_service::search_cells_by_name_and_type(app_state, search_query, CellType::Sql, limit)
-            .await?
-    };
-    let mut results = Vec::new();
+    let search_term = (!search_query.is_empty()).then_some(search_query);
+    let conversations =
+        conversation_service::search_conversations_by_name(app_state, search_term, limit).await?;
 
-    for cell in cells {
-        results.push(SearchResultItemDto {
-            id: cell.id,
-            name: cell.name.clone(),
-            entity_type: EntityType::SqlCell.as_str().to_string(),
-            updated_at: cell.updated_at,
-        });
-    }
-
-    Ok(results)
+    Ok(conversations
+        .into_iter()
+        .map(|conversation| SearchResultItemDto {
+            id: conversation.id,
+            name: Some(conversation.name),
+            entity_type: EntityType::Conversation.as_str().to_string(),
+            updated_at: conversation.updated_at,
+            canvas_id: None,
+        })
+        .collect())
 }
 
-async fn search_chart_cells(
+async fn search_cells(
     app_state: &AppState,
     search_query: &str,
+    cell_type: CellType,
+    entity_type: EntityType,
     limit: u64,
 ) -> Result<Vec<SearchResultItemDto>, sea_orm::DbErr> {
     let cells = if search_query.is_empty() {
-        cell_service::get_last_modified_cells_by_type(app_state, CellType::Chart, limit).await?
+        cell_service::get_last_modified_cells_by_type(app_state, cell_type, limit).await?
     } else {
-        cell_service::search_cells_by_name_and_type(app_state, search_query, CellType::Chart, limit)
+        cell_service::search_cells_by_name_and_type(app_state, search_query, cell_type, limit)
             .await?
     };
-    let mut results = Vec::new();
 
-    for cell in cells {
-        results.push(SearchResultItemDto {
+    let mut notebook_ids: Vec<Uuid> = cells.iter().map(|cell| cell.notebook_id).collect();
+    notebook_ids.sort();
+    notebook_ids.dedup();
+    let canvas_id_by_notebook_id =
+        notebook_service::get_canvas_ids_by_notebook_ids(app_state, notebook_ids).await?;
+
+    Ok(cells
+        .into_iter()
+        .map(|cell| SearchResultItemDto {
             id: cell.id,
-            name: cell.name.clone(),
-            entity_type: EntityType::ChartCell.as_str().to_string(),
+            name: cell.name,
+            entity_type: entity_type.as_str().to_string(),
             updated_at: cell.updated_at,
-        });
+            canvas_id: canvas_id_by_notebook_id.get(&cell.notebook_id).copied(),
+        })
+        .collect())
+}
+
+async fn search_by_entity_type(
+    app_state: &AppState,
+    search_query: &str,
+    entity_type: EntityType,
+    limit: u64,
+) -> Result<Vec<SearchResultItemDto>, sea_orm::DbErr> {
+    match entity_type {
+        EntityType::Canvas => search_canvases(app_state, search_query, limit).await,
+        EntityType::Conversation => search_conversations(app_state, search_query, limit).await,
+        EntityType::SqlCell => {
+            search_cells(app_state, search_query, CellType::Sql, entity_type, limit).await
+        }
+        EntityType::ChartCell => {
+            search_cells(app_state, search_query, CellType::Chart, entity_type, limit).await
+        }
+    }
+}
+
+async fn run_search(
+    app_state: &AppState,
+    search_query: &str,
+    filters: &[&str],
+) -> Result<Vec<SearchResultItemDto>, sea_orm::DbErr> {
+    let mut results: Vec<SearchResultItemDto> = Vec::new();
+
+    for entity_type in SUPPORTED_ENTITY_TYPES {
+        if !filters.contains(&entity_type.as_str()) {
+            continue;
+        }
+        let mut entity_results = search_by_entity_type(
+            app_state,
+            search_query,
+            entity_type,
+            SEARCH_LIMIT_PER_ENTITY,
+        )
+        .await?;
+        results.append(&mut entity_results);
     }
 
+    results.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     Ok(results)
 }
 
 pub async fn search(app_state: AppState, request: SearchRequestDto) -> impl IntoResponse {
     let search_query = request.query.as_deref().unwrap_or("");
-    let limit = SEARCH_LIMIT_PER_ENTITY;
+    let requested_filters = request.filters.unwrap_or_default();
+    let filters = requested_filters
+        .iter()
+        .map(|filter| filter.as_str())
+        .collect::<Vec<_>>();
 
-    let filters = match &request.filters {
-        Some(f) if !f.is_empty() => f.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
-        _ => {
-            return (
-                StatusCode::BAD_REQUEST,
-                axum::Json(
-                    serde_json::json!({ "error": "At least one filter type must be enabled" }),
-                ),
-            );
-        }
-    };
+    let has_supported_filter = SUPPORTED_ENTITY_TYPES
+        .iter()
+        .any(|entity_type| filters.contains(&entity_type.as_str()));
 
-    let include_canvas = filters.contains(&EntityType::Canvas.as_str());
-    let include_sql_cells = filters.contains(&EntityType::SqlCell.as_str());
-    let include_chart_cells = filters.contains(&EntityType::ChartCell.as_str());
-
-    if !include_canvas && !include_sql_cells && !include_chart_cells {
+    if !has_supported_filter {
         return (
             StatusCode::BAD_REQUEST,
             axum::Json(serde_json::json!({ "error": "At least one filter type must be enabled" })),
         );
     }
 
-    let mut all_results: Vec<SearchResultItemDto> = Vec::new();
-
-    if include_canvas {
-        match search_canvases(&app_state, search_query, limit).await {
-            Ok(mut results) => all_results.append(&mut results),
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    axum::Json(serde_json::json!({ "error": e.to_string() })),
-                );
-            }
-        }
+    match run_search(&app_state, search_query, &filters).await {
+        Ok(results) => (
+            StatusCode::OK,
+            axum::Json(serde_json::json!({ "data": results })),
+        ),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(serde_json::json!({ "error": error.to_string() })),
+        ),
     }
-
-    if include_sql_cells {
-        match search_sql_cells(&app_state, search_query, limit).await {
-            Ok(mut results) => all_results.append(&mut results),
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    axum::Json(serde_json::json!({ "error": e.to_string() })),
-                );
-            }
-        }
-    }
-
-    if include_chart_cells {
-        match search_chart_cells(&app_state, search_query, limit).await {
-            Ok(mut results) => all_results.append(&mut results),
-            Err(e) => {
-                return (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    axum::Json(serde_json::json!({ "error": e.to_string() })),
-                );
-            }
-        }
-    }
-
-    all_results.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
-
-    (
-        StatusCode::OK,
-        axum::Json(serde_json::json!({
-            "data": all_results
-        })),
-    )
 }

--- a/frontend/src/api/search/constants.tsx
+++ b/frontend/src/api/search/constants.tsx
@@ -2,4 +2,5 @@ export enum EntityType {
   Canvas = "canvas",
   SqlCell = "sql_cells",
   ChartCell = "chart_cells",
+  Conversation = "conversations",
 }

--- a/frontend/src/api/search/queries.tsx
+++ b/frontend/src/api/search/queries.tsx
@@ -13,6 +13,7 @@ export type SearchResultItemDto = {
   name: string | null;
   entity_type: EntityType;
   updated_at: string;
+  canvas_id: string | null;
 };
 
 export type SearchResponseDto = {

--- a/frontend/src/components/Notebook/Cell/Cell.tsx
+++ b/frontend/src/components/Notebook/Cell/Cell.tsx
@@ -20,6 +20,7 @@ export function Cell({ cell_id }: { cell_id: string }) {
 
   return (
     <div
+      id={cell_id}
       className={styleClassName}
       onFocus={handleActivate}
       onClick={handleActivate}

--- a/frontend/src/components/Notebook/ChartCell/ChartCell.tsx
+++ b/frontend/src/components/Notebook/ChartCell/ChartCell.tsx
@@ -21,6 +21,7 @@ export function ChartCell({ cell_id }: { cell_id: string }) {
 
   return (
     <div
+      id={cell_id}
       className={containerClassName}
       onFocus={handleActivate}
       onClick={handleActivate}

--- a/frontend/src/components/Notebook/Notebook.tsx
+++ b/frontend/src/components/Notebook/Notebook.tsx
@@ -6,6 +6,7 @@ import { useNotebook } from "src/api/notebook/queries";
 import { CellType } from "src/components/Notebook/Cell/dto";
 import { KEYBOARD_SHORTCUTS } from "src/utils/keyboard_shortcuts";
 import { useHandleExecuteCell } from "src/components/Notebook/Cell";
+import { useScrollToCellFromUrl } from "src/components/Notebook/hooks";
 import { useKeyboardShortcut } from "src/utils/keyboard_shortcuts/hooks";
 import { Flex } from "src/components/design-system/Flex/Flex";
 import { useCallback, useRef, useMemo } from "react";
@@ -33,6 +34,8 @@ export function Notebook() {
   const reorderCellMutation = useReorderCell(canvasId || undefined);
 
   const clearCellOutput = useClearCellOutput();
+
+  useScrollToCellFromUrl();
 
   const handleExecute = useCallback(() => {
     const activeCellId = useStore.getState().notebook.activeCellId;

--- a/frontend/src/components/Notebook/hooks.tsx
+++ b/frontend/src/components/Notebook/hooks.tsx
@@ -1,7 +1,10 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { PaginationState, Updater } from "@tanstack/react-table";
 import classNames from "classnames";
+import { useSearchParams } from "react-router";
 import { useStore } from "src/store";
+import { SEARCH_PARAMS } from "src/constants/app_routes";
+import { useScrollToElement } from "src/utils/hooks";
 
 const INITIAL_PAGE_SIZE = 20;
 
@@ -12,6 +15,28 @@ export function useCellContainerClassName(
 ) {
   const activeCellId = useStore((state) => state.notebook.activeCellId);
   return classNames(cellId === activeCellId && activeClassName, baseClassName);
+}
+
+export function useScrollToCellFromUrl() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const cellId = searchParams.get(SEARCH_PARAMS.CELL);
+  const setActiveCellId = useStore((state) => state.notebook.setActiveCellId);
+
+  const handleScrolled = useCallback(() => {
+    if (!cellId) {
+      return;
+    }
+    setActiveCellId(cellId);
+    setSearchParams(
+      (params) => {
+        params.delete(SEARCH_PARAMS.CELL);
+        return params;
+      },
+      { replace: true }
+    );
+  }, [cellId, setActiveCellId, setSearchParams]);
+
+  useScrollToElement(cellId, handleScrolled);
 }
 
 const INITIAL_PAGE_INDEX = 0;

--- a/frontend/src/components/design-system/CommandMenu/CommandMenu.module.css
+++ b/frontend/src/components/design-system/CommandMenu/CommandMenu.module.css
@@ -167,6 +167,10 @@
   color: var(--color-text);
 }
 
+.shortcut {
+  margin-left: auto;
+}
+
 .timestamp {
   margin-left: auto;
   font-size: var(--font-size-sm);

--- a/frontend/src/components/design-system/CommandMenu/CommandMenu.tsx
+++ b/frontend/src/components/design-system/CommandMenu/CommandMenu.tsx
@@ -7,7 +7,7 @@ import { Badge } from "src/components/design-system";
 import { Flex } from "src/components/design-system";
 import { SearchResultItemDto, useSearch } from "src/api/search/queries";
 import { EntityType } from "src/api/search";
-import { APP_ROUTES } from "src/constants/app_routes";
+import { APP_ROUTES, SEARCH_PARAMS } from "src/constants/app_routes";
 import {
   KEYBOARD_SHORTCUTS,
   useKeyboardShortcut,
@@ -24,27 +24,27 @@ type CommandMenuProps = {
   onOpenChange?: (open: boolean) => void;
 };
 
+const RECENT_ITEMS_LIMIT = 5;
+
 const PageToDisplayNameMap: Record<Page, string> = {
   home: "Home",
   canvases: "Canvases",
   sql_cells: "SQL Cells",
   chart_cells: "Chart Cells",
+  conversations: "Conversations",
 };
 
-const getFilters = (currentPage: Page) => {
-  if (currentPage === "home") {
-    return [EntityType.Canvas, EntityType.ChartCell, EntityType.SqlCell];
-  }
-  if (currentPage === "canvases") {
-    return [EntityType.Canvas];
-  }
-  if (currentPage === "sql_cells") {
-    return [EntityType.SqlCell];
-  }
-  if (currentPage === "chart_cells") {
-    return [EntityType.ChartCell];
-  }
-  return [];
+const PageToFiltersMap: Record<Page, EntityType[]> = {
+  home: [
+    EntityType.Canvas,
+    EntityType.ChartCell,
+    EntityType.SqlCell,
+    EntityType.Conversation,
+  ],
+  canvases: [EntityType.Canvas],
+  sql_cells: [EntityType.SqlCell],
+  chart_cells: [EntityType.ChartCell],
+  conversations: [EntityType.Conversation],
 };
 
 export const CommandMenu = ({
@@ -61,7 +61,7 @@ export const CommandMenu = ({
   const [pages, setPages] = useState<Page[]>(["home"]);
   const currentPage = pages[pages.length - 1];
   const isHomePage = currentPage === "home";
-  const filters = getFilters(currentPage);
+  const filters = PageToFiltersMap[currentPage];
   const searchQuery = useSearch(debouncedInputValue, filters);
 
   const handleOpenChange = (newOpen: boolean) => {
@@ -129,7 +129,25 @@ export const CommandMenu = ({
     if (item.entity_type === EntityType.Canvas) {
       handleOpenChange(false);
       navigate(APP_ROUTES.CANVAS.replace(":id", item.id));
+      return;
     }
+    if (item.entity_type === EntityType.Conversation) {
+      handleOpenChange(false);
+      navigate(
+        APP_ROUTES.CONVERSATIONAL_ANALYTICS_ROUTES.CONVERSATION.replace(
+          ":id",
+          item.id
+        )
+      );
+      return;
+    }
+    if (!item.canvas_id) {
+      return;
+    }
+    handleOpenChange(false);
+    navigate(
+      `${APP_ROUTES.CANVAS.replace(":id", item.canvas_id)}?${SEARCH_PARAMS.CELL}=${item.id}`
+    );
   };
 
   const handleCreateCanvas = (value: string) => {
@@ -139,32 +157,41 @@ export const CommandMenu = ({
     return value;
   };
 
+  const handleCreateConversation = (value: string) => {
+    handleOpenChange(false);
+    navigate(APP_ROUTES.CONVERSATIONAL_ANALYTICS_ROUTES.INDEX);
+    return value;
+  };
+
+  useKeyboardShortcut(
+    () => handleCreateConversation(""),
+    KEYBOARD_SHORTCUTS.NEW_CONVERSATION
+  );
+
   const renderContent = () => {
-    if (inputValue === "" && !isHomePage) {
+    if (inputValue !== "" || !isHomePage) {
       return (
         <CommandMenuSearchResults
           data={searchQuery.data}
+          heading={inputValue === "" ? "Recent" : "Search Results"}
           onItemSelect={handleSearchResultSelect}
         />
       );
     }
-    if (inputValue !== "") {
-      return (
-        <CommandMenuSearchResults
-          data={searchQuery.data}
-          onItemSelect={handleSearchResultSelect}
-        />
-      );
-    }
-    if (isHomePage && inputValue === "") {
-      return (
+    return (
+      <React.Fragment>
         <CommandMenuHomePage
           onSelect={handlePageSelect}
           onCreateCanvas={handleCreateCanvas}
+          onCreateConversation={handleCreateConversation}
         />
-      );
-    }
-    return null;
+        <CommandMenuSearchResults
+          data={searchQuery.data?.slice(0, RECENT_ITEMS_LIMIT)}
+          heading="Recent"
+          onItemSelect={handleSearchResultSelect}
+        />
+      </React.Fragment>
+    );
   };
 
   return (

--- a/frontend/src/components/design-system/CommandMenu/CommandMenu.types.ts
+++ b/frontend/src/components/design-system/CommandMenu/CommandMenu.types.ts
@@ -1,14 +1,20 @@
 import { SearchResultItemDto } from "src/api/search/queries";
 
-export type Page = "home" | "canvases" | "sql_cells" | "chart_cells";
+export type Page =
+  | "home"
+  | "canvases"
+  | "sql_cells"
+  | "chart_cells"
+  | "conversations";
 
 export type CommandMenuHomePageProps = {
   onSelect: (page: Page) => void;
   onCreateCanvas: (value: string) => void;
+  onCreateConversation: (value: string) => void;
 };
 
 export type CommandMenuSearchResultsProps = {
   data: SearchResultItemDto[] | undefined;
+  heading: string;
   onItemSelect: (item: SearchResultItemDto) => void;
 };
-

--- a/frontend/src/components/design-system/CommandMenu/CommandMenuHomePage.tsx
+++ b/frontend/src/components/design-system/CommandMenu/CommandMenuHomePage.tsx
@@ -2,13 +2,31 @@ import { Command } from "cmdk";
 import React from "react";
 import { CommandMenuItem } from "./CommandMenuItem";
 import { CommandMenuHomePageProps } from "./CommandMenu.types";
+import { KEYBOARD_SHORTCUTS } from "src/utils/keyboard_shortcuts";
 
 export const CommandMenuHomePage = ({
   onSelect,
   onCreateCanvas,
+  onCreateConversation,
 }: CommandMenuHomePageProps) => {
   return (
     <React.Fragment>
+      <Command.Group heading="Conversations">
+        <CommandMenuItem
+          value="Search Conversations"
+          label="Search Conversations"
+          iconType="search"
+          onSelect={() => onSelect("conversations")}
+        />
+        <CommandMenuItem
+          value="New Conversation"
+          label="New Conversation"
+          iconType="add"
+          shortcut={KEYBOARD_SHORTCUTS.NEW_CONVERSATION}
+          onSelect={onCreateConversation}
+        />
+      </Command.Group>
+      <Command.Separator />
       <Command.Group heading="Canvases">
         <CommandMenuItem
           value="Search Canvases"

--- a/frontend/src/components/design-system/CommandMenu/CommandMenuItem.tsx
+++ b/frontend/src/components/design-system/CommandMenu/CommandMenuItem.tsx
@@ -1,11 +1,18 @@
 import { Command } from "cmdk";
 import { Icon } from "../Icon";
 import { IconType } from "../datatypes";
+import { Kbd } from "../Kbd";
+import {
+  getShortcutDisplayString,
+  KeyboardShortcut,
+} from "src/utils/keyboard_shortcuts/keyboard_shortcuts";
+import styles from "./CommandMenu.module.css";
 
 type CommandMenuItemProps = {
   value: string;
   label: string;
   iconType?: IconType;
+  shortcut?: KeyboardShortcut;
   onSelect?: (value: string) => void;
 };
 
@@ -13,12 +20,18 @@ export const CommandMenuItem = ({
   value,
   label,
   iconType,
+  shortcut,
   onSelect,
 }: CommandMenuItemProps) => {
   return (
     <Command.Item value={value} onSelect={onSelect}>
       {iconType && <Icon type={iconType} color="default"></Icon>}
       {label}
+      {shortcut && (
+        <Kbd className={styles.shortcut}>
+          {getShortcutDisplayString(shortcut)}
+        </Kbd>
+      )}
     </Command.Item>
   );
 };

--- a/frontend/src/components/design-system/CommandMenu/CommandMenuSearchResults.tsx
+++ b/frontend/src/components/design-system/CommandMenu/CommandMenuSearchResults.tsx
@@ -9,16 +9,22 @@ const EntityNameMap: Record<EntityType, string> = {
   [EntityType.Canvas]: "Canvas",
   [EntityType.SqlCell]: "SQL Cell",
   [EntityType.ChartCell]: "Chart Cell",
+  [EntityType.Conversation]: "Conversation",
 };
 
-const EntityBadgeVariantMap: Record<EntityType, "blue" | "green" | "yellow"> = {
+const EntityBadgeVariantMap: Record<
+  EntityType,
+  "blue" | "green" | "yellow" | "default"
+> = {
   [EntityType.Canvas]: "blue",
   [EntityType.SqlCell]: "green",
   [EntityType.ChartCell]: "yellow",
+  [EntityType.Conversation]: "default",
 };
 
 export const CommandMenuSearchResults = ({
   data,
+  heading,
   onItemSelect,
 }: CommandMenuSearchResultsProps) => {
   if (!data || data.length === 0) {
@@ -26,7 +32,7 @@ export const CommandMenuSearchResults = ({
   }
 
   return (
-    <Command.Group heading="Search Results">
+    <Command.Group heading={heading}>
       {data.map((item) => {
         const entityName = EntityNameMap[item.entity_type];
         const badgeVariant = EntityBadgeVariantMap[item.entity_type];

--- a/frontend/src/constants/app_routes.tsx
+++ b/frontend/src/constants/app_routes.tsx
@@ -1,3 +1,7 @@
+export const SEARCH_PARAMS = {
+  CELL: "cell",
+};
+
 export const APP_ROUTES = {
   INDEX: "/",
   CANVAS: "/canvas/:id",

--- a/frontend/src/utils/hooks.tsx
+++ b/frontend/src/utils/hooks.tsx
@@ -1,6 +1,38 @@
 import { useState, useEffect, useMemo } from "react";
 import debounce from "lodash.debounce";
 
+const ELEMENT_LOOKUP_TIMEOUT_MS = 3000;
+
+export function useScrollToElement(
+  elementId: string | null,
+  onScrolled?: () => void
+) {
+  useEffect(() => {
+    if (!elementId) {
+      return;
+    }
+
+    let frameId = 0;
+    const startedAt = performance.now();
+
+    const scrollWhenAvailable = () => {
+      const element = document.getElementById(elementId);
+      if (element) {
+        element.scrollIntoView({ behavior: "smooth", block: "center" });
+        onScrolled?.();
+        return;
+      }
+      if (performance.now() - startedAt > ELEMENT_LOOKUP_TIMEOUT_MS) {
+        return;
+      }
+      frameId = requestAnimationFrame(scrollWhenAvailable);
+    };
+
+    frameId = requestAnimationFrame(scrollWhenAvailable);
+    return () => cancelAnimationFrame(frameId);
+  }, [elementId, onScrolled]);
+}
+
 export function useDebouncedValue<T>(value: T, delay: number = 300): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
 

--- a/frontend/src/utils/keyboard_shortcuts/keyboard_shortcuts.tsx
+++ b/frontend/src/utils/keyboard_shortcuts/keyboard_shortcuts.tsx
@@ -26,6 +26,12 @@ export const KEYBOARD_SHORTCUTS = {
     description: "Open the command menu",
     preventDefault: true,
   },
+  NEW_CONVERSATION: {
+    key: "o",
+    modifiers: ["meta", "shift"],
+    description: "Start a new conversation",
+    preventDefault: true,
+  },
   ADD_SQL_CELL: {
     key: "l",
     modifiers: ["meta", "shift"],


### PR DESCRIPTION
Closes #132

## Summary

Conversations are now searchable from the Cmd+K command menu. While scoping the change, three adjacent gaps surfaced in the existing menu and are fixed here too.

## Changes

**Conversations are searchable**

- `EntityType::Conversation` added to the search service, searched by name and ordered by `updated_at`, consistent with canvases and cells.
- Search delegates to the `list_conversations` repository query added in #131, so it inherits that query's `LIKE` escaping for `\`, `%`, and `_` rather than duplicating the logic.
- Selecting a result navigates to `/conversational_analytics/conversation/:id`.

**Cell results now navigate (pre-existing bug)**

Selecting a SQL or chart cell result previously did nothing — `handleSearchResultSelect` only handled `EntityType.Canvas`. A cell carries `notebook_id`, not `canvas_id`, so the result DTO gains `canvas_id`, resolved through a single batched notebook lookup (`get_canvas_ids_by_notebook_ids`) to avoid an N+1. Selecting a cell navigates to `/canvas/:canvasId?cell=<cellId>`, which scrolls the cell into view and marks it active. A result with a null `canvas_id` is skipped rather than routing to a broken URL.

**New Conversation action + `Cmd+Shift+O`**

Mirrors the existing Create Canvas action. Registered alongside `Cmd+K` so both have the same reach.

**Recent items**

The backend already returned last-modified items for an empty query; the home page discarded them. It now shows a `Recent` group under the static actions, capped at 5.

## Notable implementation detail

Scroll-to-cell is split in two so the reusable half isn't tied to notebooks:

- `useScrollToElement(elementId, onScrolled)` in `src/utils/hooks.tsx` — cells render only after the canvas and notebook queries resolve, so a mount-time scroll would miss the element. It polls via `requestAnimationFrame` until the element appears, capped at 3s. Nothing cell-specific.
- `useScrollToCellFromUrl()` in `components/Notebook/hooks.tsx` — reads `?cell=`, sets `activeCellId` (reusing the existing active-cell outline for highlight), and clears the param so the scroll doesn't re-fire.

## Refactor

`search/service.rs` repeated an identical `match … return 500` block per entity; a fourth entity would have made four copies. Those collapse into `run_search` using `?` with one error match, and the duplicated filter validation becomes a single check driven by `SUPPORTED_ENTITY_TYPES`. Adding a fifth entity is now one enum arm plus one match arm.

## Breaking changes

None. `SearchResultItemDto` gains `canvas_id`, which is additive.

## Testing

Per project convention, no tests added. Verified with `cargo check` (clean; remaining warnings are pre-existing in `entity/prelude.rs`), `tsc --noEmit`, `vite build`, and ESLint (0 errors).

## Out of scope

- **Conversation message-content search.** Name-only keeps parity with canvases and cells; content search needs a join across `conversation_message_content`, snippet extraction, and a text index. Worth its own issue.
- **Mounting `CommandMenu` in `ProtectedRoute`.** `SearchBar` is only rendered on Home, Canvases, and Conversational Analytics, so Cmd+K still does nothing on Settings, Profile, and canvas detail pages. Deliberate; worth a follow-up.

## Screenshots

UI changes are to the Cmd+K menu (new Conversations group, New Conversation action, Recent group) — screenshots to follow.