### PR TITLE
feat(conversational-analytics): add result narration agent

### DIFF
--- a/backend/src/ai/agent_utils.rs
+++ b/backend/src/ai/agent_utils.rs
@@ -27,6 +27,7 @@ pub enum AgentName {
     FunctionalRoleAnalysisAgent,
     HypothesisGenerationAgent,
     IntegrateCandidatePlanAgent,
+    ResultNarrationAgent,
     RouterAgent,
     SchemaLinkingFinalSynthesisAgent,
     SqlGenerationAgent,
@@ -53,7 +54,9 @@ impl ModelClient {
     }
 
     pub fn openai(api_key: &str) -> Result<Self, Error> {
-        let client = openai::CompletionsClient::builder().api_key(api_key).build()?;
+        let client = openai::CompletionsClient::builder()
+            .api_key(api_key)
+            .build()?;
         Ok(Self::OpenAI(client))
     }
 

--- a/backend/src/ai/dto.rs
+++ b/backend/src/ai/dto.rs
@@ -195,7 +195,6 @@ pub struct VisualizationRecommendation {
     pub y_axis: Option<String>,
     pub category: Option<String>,
     pub value: Option<String>,
-    pub reasoning: String,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
@@ -232,7 +231,7 @@ pub struct ConversationHistoryTurn {
     pub generated_sql: Option<String>,
 }
 
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "event_name", content = "data", rename_all = "snake_case")]
 pub enum Event {
     Starting,
@@ -276,8 +275,14 @@ pub enum Event {
     RecommendedVisualization {
         visualization: VisualizationRecommendation,
     },
+    Narrating,
+    Narrated {
+        narration: String,
+    },
     Routing,
-    Routed { decision: RouterDecision },
+    Routed {
+        decision: RouterDecision,
+    },
     AwaitingClarification,
     Rejected,
     GeneratingCanvas,
@@ -324,8 +329,22 @@ pub struct CanvasPlanChart {
     pub category: Option<String>,
     pub value: Option<String>,
     pub aggregate_function: Option<crate::cell::constants::AggregateFunction>,
-    pub grid_width: Option<u16>,
-    pub grid_height: Option<u16>,
+    pub grid_width: Option<i32>,
+    pub grid_height: Option<i32>,
+}
+
+impl CanvasPlanChart {
+    pub fn grid_width_units(&self) -> Option<u16> {
+        to_grid_units(self.grid_width)
+    }
+
+    pub fn grid_height_units(&self) -> Option<u16> {
+        to_grid_units(self.grid_height)
+    }
+}
+
+fn to_grid_units(value: Option<i32>) -> Option<u16> {
+    value.map(|v| v.clamp(0, u16::MAX as i32) as u16)
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]

--- a/backend/src/ai/mod.rs
+++ b/backend/src/ai/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod canvas_generation_agent;
 pub(crate) mod conversation_name_agent;
 pub(crate) mod dto;
 pub(crate) mod followup_questions_agent;
+pub(crate) mod result_narration_agent;
 pub(crate) mod router_agent;
 pub(crate) mod suggested_questions_agent;
 pub(crate) mod text_to_sql_agent;

--- a/backend/src/ai/result_narration_agent/mod.rs
+++ b/backend/src/ai/result_narration_agent/mod.rs
@@ -1,0 +1,61 @@
+mod system_prompt;
+mod user_prompt;
+
+use crate::ai::agent_utils::{AgentName, ModelRole};
+use crate::ai::dto::{Event, EventChannels};
+use crate::common::AppState;
+use crate::database::constants::QueryResult;
+use anyhow::Result;
+
+const NARRATION_SAMPLE_ROWS: usize = 50;
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+struct NarrationResponse {
+    narration: String,
+}
+
+pub async fn execute(
+    app_state: &AppState,
+    question: &str,
+    sql: &str,
+    query_result: &QueryResult,
+    channels: &EventChannels,
+) {
+    channels.send_sse_only(Event::Narrating).await;
+    match narrate(app_state, question, sql, query_result).await {
+        Ok(narration) if !narration.trim().is_empty() => {
+            let _ = channels.send(Event::Narrated { narration }).await;
+        }
+        Ok(_) => tracing::error!("result narration: agent returned empty narration"),
+        Err(e) => tracing::error!("result narration: generation failed: {e}"),
+    }
+}
+
+async fn narrate(
+    app_state: &AppState,
+    question: &str,
+    sql: &str,
+    query_result: &QueryResult,
+) -> Result<String> {
+    let model_client = app_state.require_model_client().await?;
+    let agent = model_client.build_agent(
+        ModelRole::Default,
+        AgentName::ResultNarrationAgent,
+        system_prompt::SystemPrompt::NarrateResult.as_str(),
+        0.3,
+        500,
+    );
+
+    let rows = &query_result.data[..query_result.data.len().min(NARRATION_SAMPLE_ROWS)];
+    let prompt = user_prompt::UserPrompt::NarrateResult {
+        question,
+        sql,
+        columns: &query_result.columns,
+        rows,
+        total_row_count: query_result.data.len(),
+    }
+    .render();
+
+    let response: NarrationResponse = agent.prompt_typed(prompt).await?;
+    Ok(response.narration)
+}

--- a/backend/src/ai/result_narration_agent/system_prompt.rs
+++ b/backend/src/ai/result_narration_agent/system_prompt.rs
@@ -1,0 +1,38 @@
+use indoc::indoc;
+
+const NARRATE_RESULT: &str = indoc! {r#"
+    You are an expert data analyst. You are given a user's question, the SQL that
+    answered it, and the rows that SQL returned. Answer the question in prose, the
+    way an analyst would when asked across a desk.
+
+    ## RULES
+    1. Write one to three sentences. Plain prose, no markdown, no bullet points.
+    2. Lead with the direct answer to the question.
+    3. Quote concrete figures from the rows. Call out comparisons, deltas, and
+       leaders when the data contains them.
+    4. Never mention SQL, queries, charts, tables, columns, or rows. The reader
+       asked a business question and wants a business answer.
+    5. When the result is empty, say plainly that nothing matched.
+    6. When you are shown a sample of a larger result, describe only what the
+       sample supports. Do not claim a total, maximum, or ranking you cannot see.
+    7. Describe what the data shows. Do not speculate about causes and do not
+       recommend actions.
+
+    ## OUTPUT FORMAT
+    Always respond in this exact JSON format:
+    {
+        "narration": "Your one to three sentence answer."
+    }
+"#};
+
+pub enum SystemPrompt {
+    NarrateResult,
+}
+
+impl SystemPrompt {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::NarrateResult => NARRATE_RESULT,
+        }
+    }
+}

--- a/backend/src/ai/result_narration_agent/user_prompt.rs
+++ b/backend/src/ai/result_narration_agent/user_prompt.rs
@@ -1,0 +1,67 @@
+use indoc::indoc;
+
+const NARRATE_RESULT: &str = indoc! {r#"
+    ### USER QUESTION
+    {question}
+
+    ### SQL THAT ANSWERED IT
+    {sql}
+
+    ### RESULT COLUMNS
+    {columns}
+
+    ### RESULT ROWS
+    {rows}
+
+    ### ROW COUNT
+    {row_count_note}
+
+    Answer the question.
+"#};
+
+pub enum UserPrompt<'a> {
+    NarrateResult {
+        question: &'a str,
+        sql: &'a str,
+        columns: &'a [serde_json::Value],
+        rows: &'a [serde_json::Value],
+        total_row_count: usize,
+    },
+}
+
+impl<'a> UserPrompt<'a> {
+    pub fn render(&self) -> String {
+        match self {
+            UserPrompt::NarrateResult {
+                question,
+                sql,
+                columns,
+                rows,
+                total_row_count,
+            } => {
+                let columns_str =
+                    serde_json::to_string_pretty(columns).unwrap_or_else(|_| "[]".to_string());
+                let rows_str =
+                    serde_json::to_string_pretty(rows).unwrap_or_else(|_| "[]".to_string());
+                let row_count_note = if rows.len() < *total_row_count {
+                    format!(
+                        "Showing the first {} of {} rows.",
+                        rows.len(),
+                        total_row_count
+                    )
+                } else {
+                    format!(
+                        "{} rows in total. This is the complete result.",
+                        total_row_count
+                    )
+                };
+                NARRATE_RESULT
+                    .replace("{question}", question)
+                    .replace("{sql}", sql)
+                    .replace("{columns}", &columns_str)
+                    .replace("{rows}", &rows_str)
+                    .replace("{row_count_note}", &row_count_note)
+            }
+        }
+    }
+}

--- a/backend/src/ai/visualization_agent/mod.rs
+++ b/backend/src/ai/visualization_agent/mod.rs
@@ -4,8 +4,7 @@ mod user_prompt;
 use crate::ai::agent_utils::{AgentName, ModelRole};
 use crate::ai::dto::{Event, EventChannels, VisualizationRecommendation};
 use crate::common::AppState;
-use crate::database::service::execute_sql_query;
-use crate::entity;
+use crate::database::constants::QueryResult;
 use anyhow::Result;
 use tracing::info;
 
@@ -13,20 +12,10 @@ const VISUALIZATION_SAMPLE_ROWS: usize = 5;
 
 pub async fn execute(
     app_state: &AppState,
-    connection: &entity::connection::Model,
     question: &str,
-    sql: &str,
+    query_result: &QueryResult,
     channels: &EventChannels,
 ) -> Result<()> {
-    channels.send_sse_only(Event::ExecutingQuery).await;
-    let query_result = execute_sql_query(connection, sql).await?;
-    channels
-        .send_sse_only(Event::ExecutedQuery {
-            columns: query_result.columns.clone(),
-            data: query_result.data.clone(),
-        })
-        .await;
-
     channels
         .send_sse_only(Event::RecommendingVisualization)
         .await;

--- a/backend/src/ai/visualization_agent/system_prompt.rs
+++ b/backend/src/ai/visualization_agent/system_prompt.rs
@@ -24,8 +24,7 @@ const RECOMMENDATION: &str = indoc! {r#"
         "x_axis": "column_name or null",
         "y_axis": "column_name or null",
         "category": "column_name or null (for PIE)",
-        "value": "column_name or null (for PIE)",
-        "reasoning": "One sentence explaining the choice"
+        "value": "column_name or null (for PIE)"
     }
 "#};
 

--- a/backend/src/canvas/service.rs
+++ b/backend/src/canvas/service.rs
@@ -261,7 +261,8 @@ pub async fn generate_canvas_from_plan(
             chart_cell_count += 1;
             order += 1;
 
-            let (x, y, width, height) = packer.place(chart.grid_width, chart.grid_height);
+            let (x, y, width, height) =
+                packer.place(chart.grid_width_units(), chart.grid_height_units());
             placements.push(DashboardChartPlacement {
                 cell_id: chart_cell.id,
                 notebook_id,

--- a/backend/src/cell/service.rs
+++ b/backend/src/cell/service.rs
@@ -460,6 +460,14 @@ async fn execute_query_and_format_results(
     }
 }
 
+fn strip_trailing_semicolons(query: &str) -> String {
+    let mut trimmed = query.trim_end();
+    while let Some(stripped) = trimmed.strip_suffix(';') {
+        trimmed = stripped.trim_end();
+    }
+    trimmed.to_string()
+}
+
 fn build_aggregated_query(
     source_query: &str,
     x_axis: &str,
@@ -754,7 +762,7 @@ async fn get_source_cell_for_chart(
     };
 
     let source_query = match get_sql_query_from_cell(&source_cell) {
-        Ok(query) => query,
+        Ok(query) => strip_trailing_semicolons(&query),
         Err(err) => return Err(err),
     };
 

--- a/backend/src/conversational_analytics/conversation/constants.rs
+++ b/backend/src/conversational_analytics/conversation/constants.rs
@@ -123,6 +123,7 @@ impl ConversationStatus {
 pub enum ContentType {
     Text,
     DataAnalysisResponse,
+    Narration,
 }
 
 impl fmt::Display for ContentType {
@@ -130,6 +131,7 @@ impl fmt::Display for ContentType {
         match self {
             ContentType::Text => write!(f, "TEXT"),
             ContentType::DataAnalysisResponse => write!(f, "DATA_ANALYSIS_RESPONSE"),
+            ContentType::Narration => write!(f, "NARRATION"),
         }
     }
 }
@@ -141,6 +143,7 @@ impl FromStr for ContentType {
         match s {
             "TEXT" => Ok(ContentType::Text),
             "DATA_ANALYSIS_RESPONSE" => Ok(ContentType::DataAnalysisResponse),
+            "NARRATION" => Ok(ContentType::Narration),
             _ => Err(format!("Invalid content type: {}", s)),
         }
     }

--- a/backend/src/conversational_analytics/conversation/service.rs
+++ b/backend/src/conversational_analytics/conversation/service.rs
@@ -9,6 +9,7 @@ use crate::ai::conversation_name_agent;
 use crate::ai::dto::EventChannels;
 use crate::ai::dto::{ConversationHistoryTerminalStatus, ConversationHistoryTurn, RouterCode};
 use crate::ai::followup_questions_agent;
+use crate::ai::result_narration_agent;
 use crate::ai::router_agent;
 use crate::ai::text_to_sql_agent;
 use crate::ai::visualization_agent;
@@ -34,6 +35,7 @@ use crate::conversational_analytics::message_content::dto::{
 use crate::conversational_analytics::message_content::service as message_content_service;
 use crate::conversational_analytics::segment;
 use crate::data_catalog;
+use crate::database::service::execute_sql_query;
 use crate::entity;
 use axum::response::sse::{Event, Sse};
 use sea_orm::TransactionTrait;
@@ -632,8 +634,35 @@ async fn run_pipeline(
             let sql =
                 text_to_sql_agent::execute(app_state, connection, effective_question, channels)
                     .await?;
-            visualization_agent::execute(app_state, connection, effective_question, &sql, channels)
-                .await?;
+
+            channels
+                .send_sse_only(crate::ai::dto::Event::ExecutingQuery)
+                .await;
+            let query_result = execute_sql_query(connection, &sql).await?;
+            channels
+                .send_sse_only(crate::ai::dto::Event::ExecutedQuery {
+                    columns: query_result.columns.clone(),
+                    data: query_result.data.clone(),
+                })
+                .await;
+
+            let (_, visualization_result) = tokio::join!(
+                result_narration_agent::execute(
+                    app_state,
+                    effective_question,
+                    &sql,
+                    &query_result,
+                    channels
+                ),
+                visualization_agent::execute(
+                    app_state,
+                    effective_question,
+                    &query_result,
+                    channels
+                ),
+            );
+            visualization_result?;
+
             send_followup_questions(
                 app_state,
                 connection,
@@ -721,6 +750,13 @@ async fn send_followup_questions(
         .await;
 }
 
+fn content_type_for_event(event: &crate::ai::dto::Event) -> ContentType {
+    match event {
+        crate::ai::dto::Event::Narrated { .. } => ContentType::Narration,
+        _ => ContentType::DataAnalysisResponse,
+    }
+}
+
 async fn persist_events(
     db: &sea_orm::DatabaseConnection,
     conversation_message_id: Uuid,
@@ -731,7 +767,7 @@ async fn persist_events(
         let create_dto = CreateConversationMessageContentDto {
             conversation_message_id,
             sequence_number,
-            content_type: ContentType::DataAnalysisResponse.to_string(),
+            content_type: content_type_for_event(&event).to_string(),
             content: event.to_json_string(),
             status: ConversationStatus::Active.to_string(),
         };
@@ -838,19 +874,34 @@ async fn load_conversation_history_assistant_message(
         ConversationHistoryTerminalStatus::AwaitingClarification
         | ConversationHistoryTerminalStatus::Rejected => {
             for c in contents.iter() {
-                if let Ok(value) = serde_json::from_str::<serde_json::Value>(&c.content) {
-                    if value["event_name"] == "routed" {
-                        if let Some(msg) = value["data"]["decision"]["message"].as_str() {
-                            return Some(msg.to_string());
-                        }
-                    }
+                if let Some(crate::ai::dto::Event::Routed { decision }) =
+                    parse_persisted_event(&c.content)
+                {
+                    return Some(decision.message);
                 }
             }
             None
         }
-        ConversationHistoryTerminalStatus::Completed => Some("<query executed>".to_string()),
+        ConversationHistoryTerminalStatus::Completed => {
+            Some(load_narration(&contents).unwrap_or_else(|| "<query executed>".to_string()))
+        }
         ConversationHistoryTerminalStatus::Failed => None,
     }
+}
+
+fn parse_persisted_event(content: &str) -> Option<crate::ai::dto::Event> {
+    serde_json::from_str(content).ok()
+}
+
+fn load_narration(contents: &[ConversationMessageContentDto]) -> Option<String> {
+    for c in contents.iter() {
+        if let Some(crate::ai::dto::Event::Narrated { narration }) =
+            parse_persisted_event(&c.content)
+        {
+            return Some(narration);
+        }
+    }
+    None
 }
 
 async fn load_generated_sql(
@@ -874,12 +925,9 @@ async fn load_generated_sql(
         };
     let mut generated_sql: Option<String> = None;
     for c in contents {
-        if let Ok(value) = serde_json::from_str::<serde_json::Value>(&c.content) {
-            if value["event_name"] == "generated_sql" {
-                if let Some(sql) = value["data"]["sql"].as_str() {
-                    generated_sql = Some(sql.to_string());
-                }
-            }
+        if let Some(crate::ai::dto::Event::GeneratedSql { sql }) = parse_persisted_event(&c.content)
+        {
+            generated_sql = Some(sql);
         }
     }
     generated_sql

--- a/backend/src/data_catalog/dto.rs
+++ b/backend/src/data_catalog/dto.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Database {
     pub name: String,
     pub description: String,
@@ -106,7 +106,7 @@ impl Database {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Schema {
     pub name: String,
     pub description: String,
@@ -147,7 +147,7 @@ impl Schema {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Table {
     pub name: String,
     pub description: String,
@@ -194,7 +194,7 @@ impl Table {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Column {
     pub name: String,
     pub data_type: String,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -314,15 +314,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -355,20 +355,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -392,9 +392,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4064,20 +4064,20 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
-      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/type-utils": "8.56.0",
-        "@typescript-eslint/utils": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4087,15 +4087,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4103,16 +4103,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
-      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4124,18 +4124,18 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
-      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.0",
-        "@typescript-eslint/types": "^8.56.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4146,18 +4146,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
-      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4168,9 +4168,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
-      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4181,21 +4181,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
-      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0",
-        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4206,13 +4206,13 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
-      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4224,21 +4224,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
-      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.56.0",
-        "@typescript-eslint/tsconfig-utils": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/visitor-keys": "8.56.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4248,59 +4248,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
-      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.0",
-        "@typescript-eslint/types": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4311,17 +4311,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
-      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4333,9 +4333,9 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
-      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4372,9 +4372,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4395,9 +4395,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4454,9 +4454,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4794,25 +4794,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -4831,7 +4831,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -5270,10 +5270,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6368,6 +6378,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6457,9 +6480,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6523,16 +6546,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.56.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.0.tgz",
-      "integrity": "sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.56.0",
-        "@typescript-eslint/parser": "8.56.0",
-        "@typescript-eslint/typescript-estree": "8.56.0",
-        "@typescript-eslint/utils": "8.56.0"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6543,7 +6566,7 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici-types": {

--- a/frontend/src/api/conversational_analytics/queries.tsx
+++ b/frontend/src/api/conversational_analytics/queries.tsx
@@ -6,6 +6,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { ApiService } from "src/utils/api_client";
+import { ApiError } from "src/api/dto";
 import { API_ENDPOINTS } from "src/constants/api_endpoints";
 import {
   CreateConversationDto,
@@ -174,11 +175,18 @@ export const useConversations = (params: ListConversationsParams = {}) => {
   });
 };
 
+const isClientError = (error: unknown): boolean =>
+  error instanceof ApiError && error.status >= 400 && error.status < 500;
+
+export const isConversationNotFoundError = (error: unknown): boolean =>
+  error instanceof ApiError && error.status === 404;
+
 export const useConversation = (conversationId: string) => {
   return useQuery({
     queryKey: conversationKeys.detail(conversationId),
     queryFn: () => conversationalAnalyticsApi.getConversation(conversationId),
     enabled: !!conversationId,
+    retry: (failureCount, error) => !isClientError(error) && failureCount < 3,
   });
 };
 

--- a/frontend/src/components/ConversationalAnalytics/AgentTrace/AgentTrace.tsx
+++ b/frontend/src/components/ConversationalAnalytics/AgentTrace/AgentTrace.tsx
@@ -11,12 +11,14 @@ import { rotateToggleTransition } from "src/components/design-system/animation";
 import {
   AgentEventName,
   extractCanvasGenerated,
+  extractNarration,
   type AgentEvent,
   type ConversationMessageContentDto,
   type GeneratedSqlData,
   type RecommendedVisualizationData,
 } from "src/components/ConversationalAnalytics/dto";
 import { CanvasGeneratedCard } from "src/components/ConversationalAnalytics/CanvasGeneratedCard";
+import { ResultNarration } from "src/components/ConversationalAnalytics/ResultNarration";
 import {
   parseEvent,
   isCompletedEvent,
@@ -72,6 +74,8 @@ export function AgentTrace({ connectionId, contents }: AgentTraceProps) {
   }, [events]);
 
   const canvas = useMemo(() => extractCanvasGenerated(events), [events]);
+
+  const narration = useMemo(() => extractNarration(events), [events]);
 
   if (events.length === 0 && !routerDecision) return null;
 
@@ -138,6 +142,7 @@ export function AgentTrace({ connectionId, contents }: AgentTraceProps) {
           </Box>
         </Collapsible>
       )}
+      {narration && <ResultNarration text={narration} />}
       {sql && visualization && (
         <QueryResultChartContainer
           connectionId={connectionId}

--- a/frontend/src/components/ConversationalAnalytics/AgentTrace/trace-steps.tsx
+++ b/frontend/src/components/ConversationalAnalytics/AgentTrace/trace-steps.tsx
@@ -69,6 +69,7 @@ export const STEP_LABELS: Record<string, string> = {
   [AgentEventName.ExecutingQuery]: "Executing Query",
   [AgentEventName.RecommendingVisualization]: "Recommending Visualization",
   [AgentEventName.RecommendedVisualization]: "Recommended Visualization",
+  [AgentEventName.Narrating]: "Summarizing results…",
   [AgentEventName.GeneratingCanvas]: "Generating canvas…",
 };
 
@@ -81,6 +82,7 @@ export const TRACE_HIDDEN_EVENTS = new Set<string>([
   AgentEventName.Rejected,
   AgentEventName.ExecutedQuery,
   AgentEventName.RecommendedVisualization,
+  AgentEventName.Narrated,
   AgentEventName.SuggestedFollowups,
   AgentEventName.CanvasGenerated,
 ]);

--- a/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/ExistingConversationPanel.tsx
+++ b/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/ExistingConversationPanel.tsx
@@ -1,11 +1,13 @@
-import { useParams } from "react-router";
+import { useNavigate, useParams } from "react-router";
 import {
   ConversationMessageDto,
+  isConversationNotFoundError,
   MessageStatus,
   Sender,
   useAppendUserMessage,
   useConversation,
 } from "src/api/conversational_analytics";
+import { APP_ROUTES } from "src/constants/app_routes";
 import { ConversationActionsMenu } from "src/components/ConversationalAnalytics/ConversationActionsMenu";
 import { Flex, Icon, Text } from "src/components/design-system";
 import { MessageHoverFooter } from "./MessageHoverFooter";
@@ -89,12 +91,22 @@ export const ExistingConversationPanel = () => {
   const { id } = useParams<{ id: string }>();
   const conversationId = id ?? "";
   const conversationQuery = useConversation(conversationId);
+  const navigate = useNavigate();
   const startStream = useStartStream();
   const composerRef = useRef<MessageComposerHandle>(null);
   const { events: streamingEvents, isStreaming } =
     useConversationStream(conversationId);
   const appendUserMessage = useAppendUserMessage(conversationId);
   const gate = useCanSendFollowUp(conversationId);
+
+  const isNotFound = isConversationNotFoundError(conversationQuery.error);
+
+  useEffect(() => {
+    if (!isNotFound) return;
+    navigate(APP_ROUTES.CONVERSATIONAL_ANALYTICS_ROUTES.CONVERSATIONS, {
+      replace: true,
+    });
+  }, [isNotFound, navigate]);
 
   useEffect(() => {
     if (!conversationId || !conversationQuery.isSuccess) return;
@@ -193,7 +205,11 @@ export const ExistingConversationPanel = () => {
             </Flex>
           )}
           <Flex direction="column" flex="grow" overflow="scrollY">
-            <Flex direction="column" className={styles.messageColumn}>
+            <Flex
+              direction="column"
+              paddingTop="md"
+              className={styles.messageColumn}
+            >
               {renderMessages()}
               {(isStreaming || streamingEvents.length > 0) && (
                 <Flex direction="column" className={styles.messageWrapper}>

--- a/frontend/src/components/ConversationalAnalytics/QueryResultChart/QueryResultChart.module.css
+++ b/frontend/src/components/ConversationalAnalytics/QueryResultChart/QueryResultChart.module.css
@@ -7,7 +7,3 @@
   width: 100%;
   height: 300px;
 }
-
-.reasoning {
-  font-style: italic;
-}

--- a/frontend/src/components/ConversationalAnalytics/QueryResultChart/QueryResultChart.tsx
+++ b/frontend/src/components/ConversationalAnalytics/QueryResultChart/QueryResultChart.tsx
@@ -83,14 +83,7 @@ export function QueryResultChart({ chartData }: QueryResultChartProps) {
 
   return (
     <Box className={styles.container}>
-      <Flex direction="column" gap="xs">
-        <Box className={styles.reasoning}>
-          <Text fontSize="xs" color="subtle">
-            {visualization.reasoning}
-          </Text>
-        </Box>
-        <Box className={styles.chartWrapper}>{renderChart()}</Box>
-      </Flex>
+      <Box className={styles.chartWrapper}>{renderChart()}</Box>
     </Box>
   );
 }

--- a/frontend/src/components/ConversationalAnalytics/ResultNarration/ResultNarration.tsx
+++ b/frontend/src/components/ConversationalAnalytics/ResultNarration/ResultNarration.tsx
@@ -1,0 +1,20 @@
+import { Box, Text } from "src/components/design-system";
+
+const NARRATION_STYLE = { lineHeight: "var(--line-height-relaxed)" };
+
+type ResultNarrationProps = {
+  text: string;
+};
+
+export const ResultNarration = ({ text }: ResultNarrationProps) => {
+  const narration = text.trim();
+  if (!narration) return null;
+
+  return (
+    <Box width="100%" paddingX="md" paddingY="sm" sx={NARRATION_STYLE}>
+      <Text as="p" fontSize="base">
+        {narration}
+      </Text>
+    </Box>
+  );
+};

--- a/frontend/src/components/ConversationalAnalytics/ResultNarration/index.tsx
+++ b/frontend/src/components/ConversationalAnalytics/ResultNarration/index.tsx
@@ -1,0 +1,1 @@
+export { ResultNarration } from "./ResultNarration";

--- a/frontend/src/components/ConversationalAnalytics/StreamingAgentTrace/StreamingAgentTrace.tsx
+++ b/frontend/src/components/ConversationalAnalytics/StreamingAgentTrace/StreamingAgentTrace.tsx
@@ -4,9 +4,11 @@ import {
   IN_PROGRESS_EVENTS,
   extractChartData,
   extractCanvasGenerated,
+  extractNarration,
   type AgentEvent,
 } from "src/components/ConversationalAnalytics/dto";
 import { CanvasGeneratedCard } from "src/components/ConversationalAnalytics/CanvasGeneratedCard";
+import { ResultNarration } from "src/components/ConversationalAnalytics/ResultNarration";
 import {
   STEP_LABELS,
   TRACE_HIDDEN_EVENTS,
@@ -68,6 +70,7 @@ export function StreamingAgentTrace({
   const chartData = useMemo(() => extractChartData(events), [events]);
   const canvas = useMemo(() => extractCanvasGenerated(events), [events]);
   const routerDecision = useMemo(() => extractRouterDecision(events), [events]);
+  const narration = useMemo(() => extractNarration(events), [events]);
 
   if (steps.length === 0 && !isStreaming && !routerDecision) return null;
 
@@ -102,6 +105,7 @@ export function StreamingAgentTrace({
           createdAt={routerDecision.createdAt}
         />
       )}
+      {narration && <ResultNarration text={narration} />}
       {chartData && <QueryResultChart chartData={chartData} />}
       {canvas && <CanvasGeneratedCard data={canvas} />}
     </>

--- a/frontend/src/components/ConversationalAnalytics/dto.tsx
+++ b/frontend/src/components/ConversationalAnalytics/dto.tsx
@@ -175,6 +175,8 @@ export const AgentEventName = {
   ExecutedQuery: "executed_query",
   RecommendingVisualization: "recommending_visualization",
   RecommendedVisualization: "recommended_visualization",
+  Narrating: "narrating",
+  Narrated: "narrated",
   SuggestedFollowups: "suggested_followups",
   GeneratingCanvas: "generating_canvas",
   CanvasGenerated: "canvas_generated",
@@ -194,6 +196,7 @@ export const IN_PROGRESS_EVENTS = new Set<string>([
   AgentEventName.GeneratingSql,
   AgentEventName.ExecutingQuery,
   AgentEventName.RecommendingVisualization,
+  AgentEventName.Narrating,
   AgentEventName.GeneratingCanvas,
 ]);
 
@@ -268,8 +271,11 @@ export type RecommendedVisualizationData = {
     y_axis?: string;
     category?: string;
     value?: string;
-    reasoning: string;
   };
+};
+
+export type NarrationData = {
+  narration: string;
 };
 
 export type SuggestedFollowupsData = {
@@ -341,6 +347,13 @@ export function extractChartData(events: AgentEvent[]): ChartRenderData | null {
     queryData,
     visualization: vizData.visualization,
   };
+}
+
+export function extractNarration(events: AgentEvent[]): string | null {
+  const event = events.find((e) => e.event_name === AgentEventName.Narrated);
+  if (!event?.data) return null;
+  const narration = (event.data as NarrationData).narration?.trim();
+  return narration ? narration : null;
 }
 
 export function extractCanvasGenerated(


### PR DESCRIPTION
Part of #134 — does not close it.

## Summary

After SQL runs, a small agent now explains the result in prose — *"Q1 revenue was $4.2M, up 12% vs Q4."* A turn previously returned SQL and a chart but no answer in words. The visualization agent's `reasoning` field is dropped in the same change; it described the chart, not the data.

The remaining #134 items — multi-graph output per turn, filtering irrelevant questions from history, modifying an existing canvas instead of always creating one — are untouched.

## Backend

- New `result_narration_agent`, prompted with the question, the generated SQL, result columns, up to 50 rows and the true row count, so it can tell a sample from a complete result.
- Query execution hoisted out of `visualization_agent` into `run_pipeline`; narration and visualization now run concurrently over one `QueryResult`. The visualization agent becomes recommendation-only and drops its `connection` param.
- Narration failure is non-fatal — logged and skipped, like `send_followup_questions`, so it can't cost the user their chart.
- New `Event::Narrating` (SSE-only) and `Event::Narrated` (persisted), plus `ContentType::Narration`. `persist_events` maps event → content type instead of hardcoding one.
- Conversation history for completed turns carries the narration instead of the placeholder `"<query executed>"`, so the router and follow-up agents see what was actually answered.
- `Event` now derives `Deserialize`; the three history loaders match typed variants instead of indexing raw JSON, where a renamed field silently yielded `None`.

## Frontend

- New `ResultNarration` — plain prose between the Explanation collapsible and the chart, not inside a message bubble.
- `narrating` / `narrated` events; `narrating` drives the streaming shimmer, `narrated` is hidden from the trace step list.
- Visualization `reasoning` display removed.
- Top spacing between the conversation header and the first message, using the same `--space-md` as the inter-message gap.

## Bug fixes

Three unrelated defects hit while building this:

- **Canvas generation was fully broken.** `CanvasPlanChart.grid_width/height` were `Option<u16>`, and schemars emits `minimum`/`maximum` for sized integers, which the structured-output API rejects outright: `For 'integer' type, properties maximum, minimum are not supported`. Now `Option<i32>` — the only integer type emitting no bounds — clamped to `u16` at the boundary. Audited every structured-output type; `CanvasPlan` was the only one affected.
- **Non-existent conversation ids dead-ended** on a blank panel, after retrying the 404 three times. Now redirects to the conversation list, keyed to 404 specifically — 403 (`AiNotLive`) and 422 shouldn't throw the user off the page.
- **Chart cells failed on SQL ending in `;`.** Charts wrap the source as `FROM ({query}) AS subquery`, so a trailing semicolon gave `near ";": syntax error`.

## Breaking changes

None at the API level. No backward compatibility, by design:

- Turns from before this change have no `narrated` event and render no narration. There is no backfill.
- Existing `recommended_visualization` rows keep a now-unused `reasoning` key; serde ignores unknown fields, so no migration is needed.

## Notes

- No tests, per the project's no-proactive-tests rule.
- Verified with `cargo check`, `cargo clippy`, `tsc -b`, `eslint` and `vite build` — the frontend against react-router 8.3.0, picked up from main's major bump.
- No screenshot for the narration UI; it needs the running app.
- Not exercised against a live model — narration output quality and the canvas fix both need a real query against a connection.