### PR TITLE
feat(conversational-analytics): filter irrelevant turns from conversation history

### DIFF
--- a/backend/src/ai/canvas_generation_agent/agent.rs
+++ b/backend/src/ai/canvas_generation_agent/agent.rs
@@ -1,18 +1,18 @@
 use super::system_prompt::SystemPrompt;
 use super::user_prompt::UserPrompt;
 use crate::ai::agent_utils::{AgentName, ModelRole};
-use crate::ai::dto::{CanvasPlan, ConversationHistoryTurn};
+use crate::ai::dto::{CanvasPlan, ConversationHistory};
 use crate::common::AppState;
 use anyhow::Result;
 use tracing::info;
 
 pub async fn execute(
     app_state: &AppState,
-    conversation_history_turns: &[ConversationHistoryTurn],
+    conversation_history: &ConversationHistory,
 ) -> Result<CanvasPlan> {
     info!(
         "canvas_generation_agent: planning canvas (history_turns={})",
-        conversation_history_turns.len()
+        conversation_history.len()
     );
 
     let model_client = app_state.require_model_client().await?;
@@ -25,7 +25,7 @@ pub async fn execute(
     );
 
     let prompt = UserPrompt::Generate {
-        conversation_history_turns,
+        conversation_history,
     }
     .render();
     let plan: CanvasPlan = agent.prompt_typed::<CanvasPlan>(prompt).await?;

--- a/backend/src/ai/canvas_generation_agent/user_prompt.rs
+++ b/backend/src/ai/canvas_generation_agent/user_prompt.rs
@@ -1,8 +1,8 @@
-use crate::ai::dto::ConversationHistoryTurn;
+use crate::ai::dto::ConversationHistory;
 
 pub enum UserPrompt<'a> {
     Generate {
-        conversation_history_turns: &'a [ConversationHistoryTurn],
+        conversation_history: &'a ConversationHistory,
     },
 }
 
@@ -10,12 +10,12 @@ impl<'a> UserPrompt<'a> {
     pub fn render(&self) -> String {
         match self {
             UserPrompt::Generate {
-                conversation_history_turns,
+                conversation_history,
             } => {
                 let mut out = String::from(
                     "Design a Canvas from the conversation so far.\n\nConversation history:\n",
                 );
-                for (i, turn) in conversation_history_turns.iter().enumerate() {
+                for (i, turn) in conversation_history.into_iter().enumerate() {
                     out.push_str(&format!("\nTurn {}:\n", i + 1));
                     out.push_str(&format!("  User: {}\n", turn.user_question));
                     if let Some(sql) = &turn.generated_sql {

--- a/backend/src/ai/dto.rs
+++ b/backend/src/ai/dto.rs
@@ -214,7 +214,7 @@ pub struct RouterDecision {
     pub message: String,
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConversationHistoryTerminalStatus {
     Completed,
@@ -223,12 +223,82 @@ pub enum ConversationHistoryTerminalStatus {
     Failed,
 }
 
+impl ConversationHistoryTerminalStatus {
+    pub fn is_relevant(self, is_latest_turn: bool) -> bool {
+        match self {
+            Self::Completed => true,
+            Self::AwaitingClarification => is_latest_turn,
+            Self::Rejected | Self::Failed => false,
+        }
+    }
+}
+
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct ConversationHistoryTurn {
     pub user_question: String,
     pub terminal_status: ConversationHistoryTerminalStatus,
     pub assistant_message: Option<String>,
     pub generated_sql: Option<String>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct ConversationHistory {
+    turns: Vec<ConversationHistoryTurn>,
+}
+
+impl ConversationHistory {
+    pub fn select_relevant<T>(
+        turns: Vec<T>,
+        limit: usize,
+        status_of: impl Fn(&T) -> ConversationHistoryTerminalStatus,
+    ) -> Vec<T> {
+        let total = turns.len();
+        let relevant: Vec<T> = turns
+            .into_iter()
+            .enumerate()
+            .filter(|(index, turn)| status_of(turn).is_relevant(index + 1 == total))
+            .map(|(_, turn)| turn)
+            .collect();
+        let skip = relevant.len().saturating_sub(limit);
+        relevant.into_iter().skip(skip).collect()
+    }
+
+    pub fn from_turns(turns: Vec<ConversationHistoryTurn>, limit: usize) -> Self {
+        Self {
+            turns: Self::select_relevant(turns, limit, |turn| turn.terminal_status),
+        }
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, ConversationHistoryTurn> {
+        self.turns.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.turns.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.turns.is_empty()
+    }
+
+    pub fn has_completed_query(&self) -> bool {
+        self.turns.iter().any(|turn| {
+            matches!(
+                turn.terminal_status,
+                ConversationHistoryTerminalStatus::Completed
+            ) && turn.generated_sql.is_some()
+        })
+    }
+}
+
+impl<'a> IntoIterator for &'a ConversationHistory {
+    type Item = &'a ConversationHistoryTurn;
+    type IntoIter = std::slice::Iter<'a, ConversationHistoryTurn>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.turns.iter()
+    }
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]

--- a/backend/src/ai/followup_questions_agent/mod.rs
+++ b/backend/src/ai/followup_questions_agent/mod.rs
@@ -2,7 +2,7 @@ mod system_prompt;
 mod user_prompt;
 
 use crate::ai::agent_utils::{AgentName, ModelRole};
-use crate::ai::dto::{ConversationHistoryTerminalStatus, ConversationHistoryTurn};
+use crate::ai::dto::{ConversationHistory, ConversationHistoryTerminalStatus};
 use crate::common::AppState;
 use crate::data_catalog::dto::Database;
 use crate::entity;
@@ -15,7 +15,7 @@ struct FollowupQuestionsResponse {
     questions: Vec<String>,
 }
 
-fn format_history(history: &[ConversationHistoryTurn]) -> String {
+fn format_history(history: &ConversationHistory) -> String {
     if history.is_empty() {
         return "(none)".to_string();
     }
@@ -39,7 +39,7 @@ pub async fn suggest_followups(
     _connection: &entity::connection::Model,
     question: &str,
     sql: &str,
-    history: &[ConversationHistoryTurn],
+    history: &ConversationHistory,
     catalog: &Database,
 ) -> Result<Vec<String>> {
     let model_client = app_state.require_model_client().await?;

--- a/backend/src/ai/router_agent/agent.rs
+++ b/backend/src/ai/router_agent/agent.rs
@@ -1,7 +1,7 @@
 use super::system_prompt::SystemPrompt;
 use super::user_prompt::UserPrompt;
 use crate::ai::agent_utils::{AgentName, ModelRole};
-use crate::ai::dto::{ConversationHistoryTurn, RouterDecision};
+use crate::ai::dto::{ConversationHistory, RouterDecision};
 use crate::common::AppState;
 use anyhow::Result;
 use tracing::info;
@@ -9,12 +9,12 @@ use tracing::info;
 pub async fn execute(
     app_state: &AppState,
     question: &str,
-    conversation_history_turns: &[ConversationHistoryTurn],
+    conversation_history: &ConversationHistory,
 ) -> Result<RouterDecision> {
     info!(
         "router_agent: routing question (len={}, history_turns={})",
         question.len(),
-        conversation_history_turns.len()
+        conversation_history.len()
     );
 
     let model_client = app_state.require_model_client().await?;
@@ -28,7 +28,7 @@ pub async fn execute(
 
     let prompt = UserPrompt::Route {
         question,
-        conversation_history_turns,
+        conversation_history,
     }
     .render();
     let decision: RouterDecision = agent.prompt_typed::<RouterDecision>(prompt).await?;

--- a/backend/src/ai/router_agent/user_prompt.rs
+++ b/backend/src/ai/router_agent/user_prompt.rs
@@ -1,9 +1,9 @@
-use crate::ai::dto::ConversationHistoryTurn;
+use crate::ai::dto::ConversationHistory;
 
 pub enum UserPrompt<'a> {
     Route {
         question: &'a str,
-        conversation_history_turns: &'a [ConversationHistoryTurn],
+        conversation_history: &'a ConversationHistory,
     },
 }
 
@@ -12,13 +12,12 @@ impl<'a> UserPrompt<'a> {
         match self {
             UserPrompt::Route {
                 question,
-                conversation_history_turns,
+                conversation_history,
             } => {
-                let history_json = if conversation_history_turns.is_empty() {
+                let history_json = if conversation_history.is_empty() {
                     "[]".to_string()
                 } else {
-                    serde_json::to_string(conversation_history_turns)
-                        .unwrap_or_else(|_| "[]".to_string())
+                    serde_json::to_string(conversation_history).unwrap_or_else(|_| "[]".to_string())
                 };
                 format!(
                     "PRIOR_TURNS_OLDEST_FIRST: {history_json}\n\nCURRENT_USER_MESSAGE: {question}\n\nReturn the JSON object now."

--- a/backend/src/conversational_analytics/conversation/constants.rs
+++ b/backend/src/conversational_analytics/conversation/constants.rs
@@ -15,7 +15,9 @@ pub(super) enum PipelineOutcome {
     Rejected,
 }
 pub const CONVERSATION_HISTORY_TURN_LIMIT: usize = 5;
-pub const CONVERSATION_HISTORY_MESSAGE_LIMIT: usize = 2 * CONVERSATION_HISTORY_TURN_LIMIT + 1;
+pub const CONVERSATION_HISTORY_SCAN_TURN_LIMIT: usize = 25;
+pub const CONVERSATION_HISTORY_SCAN_MESSAGE_LIMIT: usize =
+    2 * (CONVERSATION_HISTORY_SCAN_TURN_LIMIT + 1);
 
 /// Terminal statuses:
 /// 1. Processed - Successfully processed the user or system message.

--- a/backend/src/conversational_analytics/conversation/history.rs
+++ b/backend/src/conversational_analytics/conversation/history.rs
@@ -1,0 +1,212 @@
+use crate::ai::dto::{
+    ConversationHistory, ConversationHistoryTerminalStatus, ConversationHistoryTurn,
+};
+use crate::common::AppState;
+use crate::conversational_analytics::conversation::constants::{
+    MessageStatus, CONVERSATION_HISTORY_SCAN_MESSAGE_LIMIT, CONVERSATION_HISTORY_TURN_LIMIT,
+};
+use crate::conversational_analytics::message::constants::Sender;
+use crate::conversational_analytics::message::dto::ConversationMessageDto;
+use crate::conversational_analytics::message::service as message_service;
+use crate::conversational_analytics::message_content::dto::ConversationMessageContentDto;
+use crate::conversational_analytics::message_content::service as message_content_service;
+use crate::conversational_analytics::segment;
+use sea_orm::DatabaseConnection;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+struct TurnCandidate {
+    human_message_id: Uuid,
+    assistant_message_id: Uuid,
+    terminal_status: ConversationHistoryTerminalStatus,
+}
+
+pub async fn load(
+    app_state: &AppState,
+    conversation_id: Uuid,
+    current_assistant_message_id: Uuid,
+) -> anyhow::Result<ConversationHistory> {
+    let messages = message_service::list_messages_for_conversation(
+        &app_state.database_connection,
+        conversation_id,
+        Some(CONVERSATION_HISTORY_SCAN_MESSAGE_LIMIT as u64),
+        true,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("conversation history: failed to list messages: {e}");
+        anyhow::anyhow!("failed to load conversation history: {e}")
+    })?;
+
+    let candidates = pair_turns(messages, current_assistant_message_id);
+    let selected = ConversationHistory::select_relevant(
+        candidates,
+        CONVERSATION_HISTORY_TURN_LIMIT,
+        |candidate| candidate.terminal_status,
+    );
+    let turns = hydrate(&app_state.database_connection, selected).await;
+
+    Ok(ConversationHistory::from_turns(
+        turns,
+        CONVERSATION_HISTORY_TURN_LIMIT,
+    ))
+}
+
+fn pair_turns(
+    messages: Vec<ConversationMessageDto>,
+    current_assistant_message_id: Uuid,
+) -> Vec<TurnCandidate> {
+    let mut candidates: Vec<TurnCandidate> = Vec::new();
+    let mut pending_human: Option<ConversationMessageDto> = None;
+
+    for message in messages.into_iter().rev() {
+        if message.id == current_assistant_message_id {
+            continue;
+        }
+        match message.sender.parse::<Sender>() {
+            Ok(Sender::Human) => pending_human = Some(message),
+            Ok(Sender::Assistant) => {
+                let Some(human) = pending_human.take() else {
+                    continue;
+                };
+                let Some(terminal_status) = terminal_status_of(&message.status) else {
+                    continue;
+                };
+                candidates.push(TurnCandidate {
+                    human_message_id: human.id,
+                    assistant_message_id: message.id,
+                    terminal_status,
+                });
+            }
+            Err(_) => continue,
+        }
+    }
+
+    candidates
+}
+
+fn terminal_status_of(status: &str) -> Option<ConversationHistoryTerminalStatus> {
+    match status.parse::<MessageStatus>().ok()? {
+        MessageStatus::Processed => Some(ConversationHistoryTerminalStatus::Completed),
+        MessageStatus::AwaitingClarification => {
+            Some(ConversationHistoryTerminalStatus::AwaitingClarification)
+        }
+        MessageStatus::Rejected => Some(ConversationHistoryTerminalStatus::Rejected),
+        MessageStatus::Failed => Some(ConversationHistoryTerminalStatus::Failed),
+        MessageStatus::Processing => None,
+    }
+}
+
+async fn hydrate(
+    db: &DatabaseConnection,
+    candidates: Vec<TurnCandidate>,
+) -> Vec<ConversationHistoryTurn> {
+    let message_ids: Vec<Uuid> = candidates
+        .iter()
+        .flat_map(|candidate| [candidate.human_message_id, candidate.assistant_message_id])
+        .collect();
+
+    let contents =
+        match message_content_service::list_message_content_for_messages(db, &message_ids).await {
+            Ok(contents) => contents,
+            Err(e) => {
+                tracing::error!("conversation history: failed to list message content: {e}");
+                Vec::new()
+            }
+        };
+
+    let mut by_message: HashMap<Uuid, Vec<ConversationMessageContentDto>> = HashMap::new();
+    for content in contents {
+        by_message
+            .entry(content.conversation_message_id)
+            .or_default()
+            .push(content);
+    }
+
+    candidates
+        .into_iter()
+        .map(|candidate| {
+            let human = by_message
+                .get(&candidate.human_message_id)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            let assistant = by_message
+                .get(&candidate.assistant_message_id)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            ConversationHistoryTurn {
+                user_question: plain_text(human),
+                terminal_status: candidate.terminal_status,
+                assistant_message: assistant_message(assistant, candidate.terminal_status),
+                generated_sql: generated_sql(assistant, candidate.terminal_status),
+            }
+        })
+        .collect()
+}
+
+fn plain_text(contents: &[ConversationMessageContentDto]) -> String {
+    contents
+        .first()
+        .map(|content| segment::extract_plain_text(&content.content))
+        .unwrap_or_default()
+}
+
+fn assistant_message(
+    contents: &[ConversationMessageContentDto],
+    terminal_status: ConversationHistoryTerminalStatus,
+) -> Option<String> {
+    match terminal_status {
+        ConversationHistoryTerminalStatus::AwaitingClarification
+        | ConversationHistoryTerminalStatus::Rejected => {
+            for content in contents.iter() {
+                if let Some(crate::ai::dto::Event::Routed { decision }) =
+                    parse_persisted_event(&content.content)
+                {
+                    return Some(decision.message);
+                }
+            }
+            None
+        }
+        ConversationHistoryTerminalStatus::Completed => {
+            Some(narration(contents).unwrap_or_else(|| "<query executed>".to_string()))
+        }
+        ConversationHistoryTerminalStatus::Failed => None,
+    }
+}
+
+fn generated_sql(
+    contents: &[ConversationMessageContentDto],
+    terminal_status: ConversationHistoryTerminalStatus,
+) -> Option<String> {
+    match terminal_status {
+        ConversationHistoryTerminalStatus::AwaitingClarification
+        | ConversationHistoryTerminalStatus::Rejected => return None,
+        ConversationHistoryTerminalStatus::Completed
+        | ConversationHistoryTerminalStatus::Failed => {}
+    }
+
+    let mut sql_of_turn: Option<String> = None;
+    for content in contents.iter() {
+        if let Some(crate::ai::dto::Event::GeneratedSql { sql }) =
+            parse_persisted_event(&content.content)
+        {
+            sql_of_turn = Some(sql);
+        }
+    }
+    sql_of_turn
+}
+
+fn narration(contents: &[ConversationMessageContentDto]) -> Option<String> {
+    for content in contents.iter() {
+        if let Some(crate::ai::dto::Event::Narrated { narration }) =
+            parse_persisted_event(&content.content)
+        {
+            return Some(narration);
+        }
+    }
+    None
+}
+
+fn parse_persisted_event(content: &str) -> Option<crate::ai::dto::Event> {
+    serde_json::from_str(content).ok()
+}

--- a/backend/src/conversational_analytics/conversation/mod.rs
+++ b/backend/src/conversational_analytics/conversation/mod.rs
@@ -2,6 +2,7 @@ pub mod constants;
 mod controller;
 pub mod dto;
 pub mod error;
+mod history;
 mod repository;
 pub mod service;
 

--- a/backend/src/conversational_analytics/conversation/service.rs
+++ b/backend/src/conversational_analytics/conversation/service.rs
@@ -4,10 +4,11 @@ use super::dto;
 use super::error::AppendUserMessageError;
 use super::error::ConversationError;
 use super::error::ExecuteCompletionError;
+use super::history;
 use super::repository;
 use crate::ai::conversation_name_agent;
 use crate::ai::dto::EventChannels;
-use crate::ai::dto::{ConversationHistoryTerminalStatus, ConversationHistoryTurn, RouterCode};
+use crate::ai::dto::{ConversationHistory, RouterCode};
 use crate::ai::followup_questions_agent;
 use crate::ai::result_narration_agent;
 use crate::ai::router_agent;
@@ -21,11 +22,10 @@ use crate::connection::service as connection_service;
 use crate::conversational_analytics::command::constants::{self as command_constants, Command};
 use crate::conversational_analytics::conversation::constants::ContentType;
 use crate::conversational_analytics::conversation::constants::MessageStatus;
-use crate::conversational_analytics::conversation::constants::CONVERSATION_HISTORY_MESSAGE_LIMIT;
 use crate::conversational_analytics::conversation::constants::TERMINAL_MESSAGE_STATUSES;
 use crate::conversational_analytics::message::constants::Sender;
 use crate::conversational_analytics::message::dto::{
-    ConversationMessageDto, ConversationMessageWithContentDto, CreateConversationMessageDto,
+    ConversationMessageWithContentDto, CreateConversationMessageDto,
 };
 use crate::conversational_analytics::message::repository as message_repository;
 use crate::conversational_analytics::message::service as message_service;
@@ -525,15 +525,14 @@ pub async fn execute_completion(
     tokio::spawn(async move {
         let channels = EventChannels { sse_tx, persist_tx };
         let result = async {
-            let conversation_history_turns =
-                load_conversation_history(&app_state, conversation_id, conversation_message_id)
-                    .await?;
+            let conversation_history =
+                history::load(&app_state, conversation_id, conversation_message_id).await?;
             run_pipeline(
                 &app_state,
                 &connection,
                 &question,
                 &commands,
-                &conversation_history_turns,
+                &conversation_history,
                 &channels,
             )
             .await
@@ -574,18 +573,12 @@ pub async fn execute_completion(
 
 fn resolve_command_decision(
     command: Command,
-    history: &[ConversationHistoryTurn],
+    history: &ConversationHistory,
 ) -> crate::ai::dto::RouterDecision {
     use crate::ai::dto::{RouterCode, RouterDecision};
     match command {
         Command::Canvas => {
-            let has_data = history.iter().any(|t| {
-                matches!(
-                    t.terminal_status,
-                    ConversationHistoryTerminalStatus::Completed
-                ) && t.generated_sql.is_some()
-            });
-            if has_data {
+            if history.has_completed_query() {
                 RouterDecision {
                     code: RouterCode::GenerateCanvas,
                     message: String::new(),
@@ -605,15 +598,15 @@ async fn run_pipeline(
     connection: &entity::connection::Model,
     question: &str,
     commands: &[Command],
-    conversation_history_turns: &[ConversationHistoryTurn],
+    conversation_history: &ConversationHistory,
     channels: &EventChannels,
 ) -> anyhow::Result<PipelineOutcome> {
     channels.send(crate::ai::dto::Event::Starting).await?;
     channels.send(crate::ai::dto::Event::Routing).await?;
     let decision = if let Some(command) = commands.first() {
-        resolve_command_decision(*command, conversation_history_turns)
+        resolve_command_decision(*command, conversation_history)
     } else {
-        router_agent::execute(app_state, question, conversation_history_turns).await?
+        router_agent::execute(app_state, question, conversation_history).await?
     };
     channels
         .send(crate::ai::dto::Event::Routed {
@@ -668,7 +661,7 @@ async fn run_pipeline(
                 connection,
                 effective_question,
                 &sql,
-                conversation_history_turns,
+                conversation_history,
                 channels,
             )
             .await;
@@ -679,9 +672,8 @@ async fn run_pipeline(
             channels
                 .send(crate::ai::dto::Event::GeneratingCanvas)
                 .await?;
-            let plan =
-                crate::ai::canvas_generation_agent::execute(app_state, conversation_history_turns)
-                    .await?;
+            let plan = crate::ai::canvas_generation_agent::execute(app_state, conversation_history)
+                .await?;
             let summary =
                 crate::canvas::service::generate_canvas_from_plan(app_state, connection.id, plan)
                     .await?;
@@ -716,7 +708,7 @@ async fn send_followup_questions(
     connection: &entity::connection::Model,
     question: &str,
     sql: &str,
-    conversation_history_turns: &[ConversationHistoryTurn],
+    conversation_history: &ConversationHistory,
     channels: &EventChannels,
 ) {
     let catalog = match data_catalog::get_data_catalog_of_connection(connection).await {
@@ -731,7 +723,7 @@ async fn send_followup_questions(
         connection,
         question,
         sql,
-        conversation_history_turns,
+        conversation_history,
         &catalog,
     )
     .await
@@ -774,161 +766,4 @@ async fn persist_events(
         let _ = message_content_service::create_message_content_connection(db, create_dto).await;
         sequence_number += 1;
     }
-}
-
-async fn load_conversation_history(
-    app_state: &AppState,
-    conversation_id: Uuid,
-    current_assistant_message_id: Uuid,
-) -> anyhow::Result<Vec<ConversationHistoryTurn>> {
-    let messages = message_service::list_messages_for_conversation(
-        &app_state.database_connection,
-        conversation_id,
-        Some(CONVERSATION_HISTORY_MESSAGE_LIMIT as u64),
-        true,
-    )
-    .await
-    .map_err(|e| {
-        tracing::error!("conversation history: failed to list messages: {e}");
-        anyhow::anyhow!("failed to load conversation history: {e}")
-    })?;
-
-    let mut pairs: Vec<(ConversationMessageDto, ConversationMessageDto)> = Vec::new();
-    let mut current_human: Option<ConversationMessageDto> = None;
-    for msg in messages.into_iter().rev() {
-        if msg.id == current_assistant_message_id {
-            continue;
-        }
-        if msg.sender == Sender::Human.to_string() {
-            current_human = Some(msg);
-        } else if msg.sender == Sender::Assistant.to_string() {
-            if let Some(h) = current_human.take() {
-                if msg.status != MessageStatus::Processing.to_string() {
-                    pairs.push((h, msg));
-                }
-            }
-        }
-    }
-
-    let mut conversation_history_turns: Vec<ConversationHistoryTurn> = Vec::new();
-    for (human, assistant) in pairs {
-        let terminal_status = match assistant.status.parse::<MessageStatus>() {
-            Ok(MessageStatus::Processed) => ConversationHistoryTerminalStatus::Completed,
-            Ok(MessageStatus::AwaitingClarification) => {
-                ConversationHistoryTerminalStatus::AwaitingClarification
-            }
-            Ok(MessageStatus::Rejected) => ConversationHistoryTerminalStatus::Rejected,
-            Ok(MessageStatus::Failed) => ConversationHistoryTerminalStatus::Failed,
-            _ => continue,
-        };
-
-        let user_question = load_message_text(&app_state.database_connection, human.id).await;
-        let assistant_message = load_conversation_history_assistant_message(
-            &app_state.database_connection,
-            assistant.id,
-            &terminal_status,
-        )
-        .await;
-        let generated_sql = load_generated_sql(
-            &app_state.database_connection,
-            assistant.id,
-            &terminal_status,
-        )
-        .await;
-
-        conversation_history_turns.push(ConversationHistoryTurn {
-            user_question,
-            terminal_status,
-            assistant_message,
-            generated_sql,
-        });
-    }
-    Ok(conversation_history_turns)
-}
-
-async fn load_message_text(db: &sea_orm::DatabaseConnection, message_id: Uuid) -> String {
-    match message_content_service::list_message_content_for_message(db, message_id).await {
-        Ok(contents) => contents
-            .into_iter()
-            .next()
-            .map(|c| segment::extract_plain_text(&c.content))
-            .unwrap_or_default(),
-        Err(_) => String::new(),
-    }
-}
-
-async fn load_conversation_history_assistant_message(
-    db: &sea_orm::DatabaseConnection,
-    assistant_message_id: Uuid,
-    terminal_status: &ConversationHistoryTerminalStatus,
-) -> Option<String> {
-    let contents =
-        match message_content_service::list_message_content_for_message(db, assistant_message_id)
-            .await
-        {
-            Ok(c) => c,
-            Err(_) => return None,
-        };
-
-    match terminal_status {
-        ConversationHistoryTerminalStatus::AwaitingClarification
-        | ConversationHistoryTerminalStatus::Rejected => {
-            for c in contents.iter() {
-                if let Some(crate::ai::dto::Event::Routed { decision }) =
-                    parse_persisted_event(&c.content)
-                {
-                    return Some(decision.message);
-                }
-            }
-            None
-        }
-        ConversationHistoryTerminalStatus::Completed => {
-            Some(load_narration(&contents).unwrap_or_else(|| "<query executed>".to_string()))
-        }
-        ConversationHistoryTerminalStatus::Failed => None,
-    }
-}
-
-fn parse_persisted_event(content: &str) -> Option<crate::ai::dto::Event> {
-    serde_json::from_str(content).ok()
-}
-
-fn load_narration(contents: &[ConversationMessageContentDto]) -> Option<String> {
-    for c in contents.iter() {
-        if let Some(crate::ai::dto::Event::Narrated { narration }) =
-            parse_persisted_event(&c.content)
-        {
-            return Some(narration);
-        }
-    }
-    None
-}
-
-async fn load_generated_sql(
-    db: &sea_orm::DatabaseConnection,
-    assistant_message_id: Uuid,
-    terminal_status: &ConversationHistoryTerminalStatus,
-) -> Option<String> {
-    match terminal_status {
-        ConversationHistoryTerminalStatus::AwaitingClarification
-        | ConversationHistoryTerminalStatus::Rejected => return None,
-        ConversationHistoryTerminalStatus::Completed
-        | ConversationHistoryTerminalStatus::Failed => {}
-    }
-
-    let contents =
-        match message_content_service::list_message_content_for_message(db, assistant_message_id)
-            .await
-        {
-            Ok(c) => c,
-            Err(_) => return None,
-        };
-    let mut generated_sql: Option<String> = None;
-    for c in contents {
-        if let Some(crate::ai::dto::Event::GeneratedSql { sql }) = parse_persisted_event(&c.content)
-        {
-            generated_sql = Some(sql);
-        }
-    }
-    generated_sql
 }


### PR DESCRIPTION
- Filter rejected and failed turns out of conversation history.
- Keep awaiting-clarification turns only when they are the latest turn.
- Count the history turn budget after filtering instead of before.
- Add ConversationHistory newtype that applies the rule in its constructor.
- Extract history loading into conversation/history.rs.
- Batch message content into a single query per completion.
Refs: #134