### PR TITLE
feat(conversational-analytics): reuse canvases and cap conversation length

### DIFF
--- a/backend/src/ai/canvas_generation_agent/agent.rs
+++ b/backend/src/ai/canvas_generation_agent/agent.rs
@@ -1,7 +1,7 @@
 use super::system_prompt::SystemPrompt;
 use super::user_prompt::UserPrompt;
 use crate::ai::agent_utils::{AgentName, ModelRole};
-use crate::ai::dto::{CanvasPlan, ConversationHistory};
+use crate::ai::dto::{CanvasCandidate, CanvasPlan, ConversationHistory};
 use crate::common::AppState;
 use anyhow::Result;
 use tracing::info;
@@ -9,10 +9,12 @@ use tracing::info;
 pub async fn execute(
     app_state: &AppState,
     conversation_history: &ConversationHistory,
+    candidates: &[CanvasCandidate],
 ) -> Result<CanvasPlan> {
     info!(
-        "canvas_generation_agent: planning canvas (history_turns={})",
-        conversation_history.len()
+        "canvas_generation_agent: planning canvas (history_turns={}, existing_canvases={})",
+        conversation_history.len(),
+        candidates.len()
     );
 
     let model_client = app_state.require_model_client().await?;
@@ -26,10 +28,15 @@ pub async fn execute(
 
     let prompt = UserPrompt::Generate {
         conversation_history,
+        candidates,
     }
     .render();
     let plan: CanvasPlan = agent.prompt_typed::<CanvasPlan>(prompt).await?;
 
-    info!("canvas_generation_agent: planned {} cells", plan.cells.len());
+    info!(
+        "canvas_generation_agent: planned {} operations (target_canvas_index={:?})",
+        plan.cells.len(),
+        plan.target_canvas_index
+    );
     Ok(plan)
 }

--- a/backend/src/ai/canvas_generation_agent/system_prompt.rs
+++ b/backend/src/ai/canvas_generation_agent/system_prompt.rs
@@ -11,15 +11,46 @@ impl SystemPrompt {
 }
 
 const GENERATE_CANVAS: &str = r#"
-You are a data canvas planner. Given the history of an analytics conversation (user questions and the SQL that answered them), design a Canvas: a set of notebook cells, each with a single SQL query, and for cells whose result is best shown visually, an optional chart spec. Reuse and adapt the SQL already produced in the conversation. Prefer 3-8 focused cells. Return ONLY the structured plan.
+You are a data canvas planner. A Canvas is a set of notebook cells, each holding one SQL query, plus an optional chart for cells whose result is best shown visually.
 
-CHART SPEC:
+You are given the history of an analytics conversation and every canvas that conversation has already produced, with each canvas's current cells numbered from 1.
+
+YOUR OUTPUT IS A PLAN OF CHANGES, NOT A DESCRIPTION OF THE FINISHED CANVAS. You return a list of operations that are applied to the canvas you target. Cells you do not mention are left exactly as they are. If you send a cell that is already in the canvas, you do not replace it — you create a SECOND COPY of it.
+
+STEP 1 - CHOOSE THE CANVAS. Set `target_canvas_index` to the number of the canvas to change, or leave it null to create a new one.
+
+- No canvases exist yet: leave it null.
+- The conversation is still about the subject an existing canvas covers: target that canvas.
+- The conversation has moved to a genuinely different subject: leave it null.
+- Prefer extending. Keep the number of canvases as low as the subjects allow — do not create one canvas per request.
+- The more canvases already exist, the more likely one of them is the right home. Check every one before creating another.
+
+Set `reasoning` to one sentence explaining why you chose that canvas rather than another. It is shown to the user.
+
+STEP 2 - PLAN THE CHANGES. Every entry in `cells` carries an `action`:
+
+- `create`: add a NEW cell. Requires `sql`. `title` and `chart` are optional.
+- `update`: change a cell already in the canvas. Requires `target_cell_index`, its number in the list you were shown. Set only the fields you are changing — `title`, `sql`, and/or `chart`. Omitting `chart` leaves the existing chart untouched; it does not remove it.
+- `delete`: remove a cell and its chart. Requires `target_cell_index`. Nothing else is used.
+
+Rules when extending an existing canvas:
+
+- NEVER `create` a cell whose query is already in that canvas. To change it, `update` it. To remove it, `delete` it.
+- Wrong or broken SQL in an existing cell is an `update` to that cell. It is never a `create` of a corrected copy — that leaves both the broken one and the fix.
+- Duplicate cells you were shown are removed with `delete`, one operation per copy you want gone. Describing the canvas you wish existed does not remove anything.
+- If the canvas already answers the conversation and nothing needs to change, return an empty `cells` list. That is a valid and useful answer.
+- Emit operations only for what actually changes. A typical extension is one or two operations, not a whole canvas.
+
+When creating a NEW canvas, every entry must be `create`, you must return at least one, and 3-8 focused cells is a good size. Reuse and adapt the SQL already produced in the conversation.
+
+CHART SPEC (for any `create` or `update` that sets `chart`):
 - `chart_type` must be one of: BAR, LINE, PIE, METRIC.
-- For BAR/LINE set `x_axis` and `y_axis`. For PIE set `category` and `value`. METRIC needs no axes and renders the first value of the first row.
+- BAR and LINE REQUIRE both `x_axis` and `y_axis`. PIE REQUIRES both `category` and `value` — `category` is the slice label, `value` is the slice size, and PIE uses neither `x_axis` nor `y_axis`. METRIC needs none of them and renders the first value of the first row.
+- Setting only one of the required pair is the most common mistake. A chart missing either of its two required fields is discarded and the cell is created without a chart, so fill in both.
 - All axis and category/value names MUST be column aliases produced by that cell's SQL.
 - For BAR, LINE and PIE you MUST also set `aggregate_function`, one of: MAX, MIN, SUM, COUNT, AVG. It is applied when grouping rows by `x_axis` (or `category`), so when the SQL already returns one row per group use MAX.
 
-DASHBOARD LAYOUT. Every chart is also placed on a dashboard laid out on a 12-column grid, where one row is 100px tall. Set `grid_width` (4-12 columns) and `grid_height` (3-6 rows) per chart. Charts are packed left to right in the order you list them and wrap to the next row when they no longer fit, so choose widths that add up to exactly 12 per row and avoid leaving gaps.
+DASHBOARD LAYOUT. Charts you add are appended to the canvas's dashboard, below whatever is already on it, on a 12-column grid where one row is 100px tall. Set `grid_width` (4-12 columns) and `grid_height` (3-6 rows) per chart. The charts you add are packed left to right in the order you list them and wrap to the next row when they no longer fit, so choose widths that add up to exactly 12 per row and avoid leaving gaps.
 
 Do NOT make everything full width — a dashboard of stacked full-width charts forces the user to scroll to the end. Guidance:
 - 4x3 is the default and fits three charts per row.
@@ -28,5 +59,11 @@ Do NOT make everything full width — a dashboard of stacked full-width charts f
 - METRIC charts are single numbers, so keep them at 4x3.
 - With 3 charts use 4+4+4; with 4 use 6+6 twice; with 5 use 4+4+4 then 6+6; with 6 use 4+4+4 twice.
 
-Give the canvas a short name and one-line description summarizing the analysis.
+NAME AND DESCRIPTION. Always set BOTH `name` and `description`, on every response, for extended canvases as well as new ones. They are applied to the canvas you targeted.
+
+- `name`: a short title of a few words.
+- `description`: ONE succinct sentence saying what the canvas shows. It is the canvas subtitle that sits under the title, so keep it brief.
+- `description` is NOT `reasoning`. `reasoning` explains which canvas you picked and why, and is shown separately. Never put your decision, your justification, or a summary of your changes in `description`.
+
+When extending a canvas, repeat its existing name and description to keep them, or return different ones to change them. Leaving `description` empty on an extension keeps whatever the canvas already had.
 "#;

--- a/backend/src/ai/canvas_generation_agent/user_prompt.rs
+++ b/backend/src/ai/canvas_generation_agent/user_prompt.rs
@@ -1,8 +1,32 @@
-use crate::ai::dto::ConversationHistory;
+use indoc::indoc;
+
+use crate::ai::dto::{CanvasCandidate, CanvasCandidateCell, ConversationHistory};
+
+const GENERATE: &str = indoc! {r#"
+    Design a Canvas from the conversation so far.
+
+    ### CONVERSATION HISTORY
+    {conversation_history}
+
+    ### EXISTING CANVASES IN THIS CONVERSATION
+    {existing_canvases}
+"#};
+
+const NO_EXISTING_CANVASES: &str = indoc! {r#"
+    None.
+
+    You must create a new canvas. Leave target_canvas_index null and use only create actions.
+"#};
+
+const CANVAS_SELECTION: &str = indoc! {r#"
+    Set target_canvas_index to the number of the canvas to extend, or null for a new canvas.
+    For update and delete, set target_cell_index to the cell number within that canvas.
+"#};
 
 pub enum UserPrompt<'a> {
     Generate {
         conversation_history: &'a ConversationHistory,
+        candidates: &'a [CanvasCandidate],
     },
 }
 
@@ -11,19 +35,60 @@ impl<'a> UserPrompt<'a> {
         match self {
             UserPrompt::Generate {
                 conversation_history,
-            } => {
-                let mut out = String::from(
-                    "Design a Canvas from the conversation so far.\n\nConversation history:\n",
-                );
-                for (i, turn) in conversation_history.into_iter().enumerate() {
-                    out.push_str(&format!("\nTurn {}:\n", i + 1));
-                    out.push_str(&format!("  User: {}\n", turn.user_question));
-                    if let Some(sql) = &turn.generated_sql {
-                        out.push_str(&format!("  SQL: {}\n", sql));
-                    }
-                }
-                out
-            }
+                candidates,
+            } => GENERATE
+                .replace(
+                    "{conversation_history}",
+                    &format_history(conversation_history),
+                )
+                .replace("{existing_canvases}", &format_candidates(candidates)),
         }
     }
+}
+
+fn format_history(conversation_history: &ConversationHistory) -> String {
+    conversation_history
+        .into_iter()
+        .enumerate()
+        .map(|(index, turn)| {
+            let mut turn_block = format!("Turn {}:\n  User: {}", index + 1, turn.user_question);
+            if let Some(sql) = &turn.generated_sql {
+                turn_block.push_str(&format!("\n  SQL: {}", sql));
+            }
+            turn_block
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn format_candidates(candidates: &[CanvasCandidate]) -> String {
+    if candidates.is_empty() {
+        return NO_EXISTING_CANVASES.to_string();
+    }
+    let canvases = candidates
+        .iter()
+        .enumerate()
+        .map(|(index, candidate)| format_candidate(index + 1, candidate))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    format!("{}\n\n{}", canvases, CANVAS_SELECTION)
+}
+
+fn format_candidate(number: usize, candidate: &CanvasCandidate) -> String {
+    let mut block = format!("Canvas {}: \"{}\"", number, candidate.name);
+    if let Some(description) = &candidate.description {
+        block.push_str(&format!("\n  {}", description));
+    }
+    for (index, cell) in candidate.cells.iter().enumerate() {
+        block.push_str(&format!("\n{}", format_cell(index + 1, cell)));
+    }
+    block
+}
+
+fn format_cell(number: usize, cell: &CanvasCandidateCell) -> String {
+    let chart = match &cell.chart_type {
+        Some(chart_type) => chart_type.as_str(),
+        None => "no chart",
+    };
+    format!("  Cell {}: {} [{}] {}", number, cell.title, chart, cell.sql)
 }

--- a/backend/src/ai/dto.rs
+++ b/backend/src/ai/dto.rs
@@ -360,6 +360,11 @@ pub enum Event {
         canvas_id: uuid::Uuid,
         name: String,
         description: Option<String>,
+        reused: bool,
+        reasoning: String,
+        cells_added: i32,
+        cells_updated: i32,
+        cells_removed: i32,
         sql_cell_count: i32,
         chart_cell_count: i32,
         dashboard_charts_count: i32,
@@ -411,24 +416,197 @@ impl CanvasPlanChart {
     pub fn grid_height_units(&self) -> Option<u16> {
         to_grid_units(self.grid_height)
     }
+
+    /// Accepts axis/category as synonyms, since agents mix the two vocabularies.
+    fn normalized(&self) -> Option<Self> {
+        use crate::cell::constants::ChartType;
+
+        let mut chart = self.clone();
+        match chart.chart_type {
+            ChartType::Pie => {
+                chart.category = non_empty(&self.category).or_else(|| non_empty(&self.x_axis));
+                chart.value = non_empty(&self.value).or_else(|| non_empty(&self.y_axis));
+                chart.category.as_ref()?;
+                chart.value.as_ref()?;
+            }
+            ChartType::Bar | ChartType::Line => {
+                chart.x_axis = non_empty(&self.x_axis).or_else(|| non_empty(&self.category));
+                chart.y_axis = non_empty(&self.y_axis).or_else(|| non_empty(&self.value));
+                chart.x_axis.as_ref()?;
+                chart.y_axis.as_ref()?;
+            }
+            ChartType::Metric => {}
+        }
+        Some(chart)
+    }
+}
+
+fn resolve_chart(
+    chart: Option<&CanvasPlanChart>,
+    title: &Option<String>,
+) -> Option<CanvasPlanChart> {
+    let chart = chart?;
+    let normalized = chart.normalized();
+    if normalized.is_none() {
+        tracing::warn!(
+            "canvas plan: dropped {} chart for {:?} because its axis or category fields were missing",
+            chart.chart_type.as_str(),
+            title.as_deref().unwrap_or("<untitled>")
+        );
+    }
+    normalized
 }
 
 fn to_grid_units(value: Option<i32>) -> Option<u16> {
     value.map(|v| v.clamp(0, u16::MAX as i32) as u16)
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
-pub struct CanvasPlanCell {
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct CanvasCandidateCell {
     pub title: String,
     pub sql: String,
+    pub chart_type: Option<crate::cell::constants::ChartType>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct CanvasCandidate {
+    pub id: uuid::Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub cells: Vec<CanvasCandidateCell>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CanvasCellAction {
+    Create,
+    Update,
+    Delete,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct CanvasPlanCell {
+    pub action: CanvasCellAction,
+    pub target_cell_index: Option<i32>,
+    pub title: Option<String>,
+    pub sql: Option<String>,
     pub chart: Option<CanvasPlanChart>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct CanvasPlan {
+    pub target_canvas_index: Option<i32>,
+    pub reasoning: String,
     pub name: String,
-    pub description: Option<String>,
+    pub description: String,
     pub cells: Vec<CanvasPlanCell>,
+}
+
+#[derive(Clone, Debug)]
+pub enum CanvasOp {
+    Create {
+        title: Option<String>,
+        sql: String,
+        chart: Option<CanvasPlanChart>,
+    },
+    Update {
+        index: usize,
+        title: Option<String>,
+        sql: Option<String>,
+        chart: Option<CanvasPlanChart>,
+    },
+    Delete {
+        index: usize,
+    },
+}
+
+fn to_zero_based(index: Option<i32>, len: usize) -> Option<usize> {
+    let index = usize::try_from(index?).ok()?.checked_sub(1)?;
+    (index < len).then_some(index)
+}
+
+fn non_empty(value: &Option<String>) -> Option<String> {
+    let trimmed = value.as_deref()?.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn normalize_sql(sql: &str) -> String {
+    sql.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+impl CanvasPlan {
+    pub fn resolve_target_canvas(&self, candidates: &[CanvasCandidate]) -> Option<uuid::Uuid> {
+        to_zero_based(self.target_canvas_index, candidates.len()).map(|i| candidates[i].id)
+    }
+
+    pub fn resolve_ops(&self, target: Option<&CanvasCandidate>) -> Vec<CanvasOp> {
+        let cell_count = target.map(|c| c.cells.len()).unwrap_or(0);
+        let mut present: std::collections::HashSet<String> = target
+            .map(|c| {
+                c.cells
+                    .iter()
+                    .map(|cell| normalize_sql(&cell.sql))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut ops = Vec::new();
+        for cell in self.cells.iter() {
+            let Some(op) = Self::resolve_op(cell, cell_count) else {
+                continue;
+            };
+            match &op {
+                CanvasOp::Create { title, sql, .. } => {
+                    if !present.insert(normalize_sql(sql)) {
+                        tracing::warn!(
+                            "canvas plan: dropped create of {:?} because its query is already in the target canvas",
+                            title.as_deref().unwrap_or("<untitled>")
+                        );
+                        continue;
+                    }
+                }
+                CanvasOp::Delete { index } => {
+                    if let Some(cell) = target.and_then(|c| c.cells.get(*index)) {
+                        present.remove(&normalize_sql(&cell.sql));
+                    }
+                }
+                CanvasOp::Update { .. } => {}
+            }
+            ops.push(op);
+        }
+        ops
+    }
+
+    fn resolve_op(cell: &CanvasPlanCell, cell_count: usize) -> Option<CanvasOp> {
+        match cell.action {
+            CanvasCellAction::Create => Some(CanvasOp::Create {
+                title: non_empty(&cell.title),
+                sql: non_empty(&cell.sql)?,
+                chart: resolve_chart(cell.chart.as_ref(), &cell.title),
+            }),
+            CanvasCellAction::Update => {
+                let index = to_zero_based(cell.target_cell_index, cell_count)?;
+                let title = non_empty(&cell.title);
+                let sql = non_empty(&cell.sql);
+                let chart = resolve_chart(cell.chart.as_ref(), &cell.title);
+                if title.is_none() && sql.is_none() && chart.is_none() {
+                    return None;
+                }
+                Some(CanvasOp::Update {
+                    index,
+                    title,
+                    sql,
+                    chart,
+                })
+            }
+            CanvasCellAction::Delete => Some(CanvasOp::Delete {
+                index: to_zero_based(cell.target_cell_index, cell_count)?,
+            }),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/backend/src/canvas/dto.rs
+++ b/backend/src/canvas/dto.rs
@@ -12,10 +12,15 @@ pub struct CreateCanvasResult {
 }
 
 #[derive(Debug)]
-pub struct GeneratedCanvasSummary {
+pub struct CanvasChangeSummary {
     pub canvas_id: Uuid,
     pub name: String,
     pub description: Option<String>,
+    pub reused: bool,
+    pub reasoning: String,
+    pub cells_added: i32,
+    pub cells_updated: i32,
+    pub cells_removed: i32,
     pub sql_cell_count: i32,
     pub chart_cell_count: i32,
     pub dashboard_charts_count: i32,

--- a/backend/src/canvas/repository.rs
+++ b/backend/src/canvas/repository.rs
@@ -16,6 +16,30 @@ pub async fn get_canvas(db: &DatabaseConnection, id: Uuid) -> Result<canvas::Mod
     }
 }
 
+pub async fn get_canvas_transaction(
+    txn: &DatabaseTransaction,
+    id: Uuid,
+) -> Result<canvas::Model, DbErr> {
+    let canvas = canvas::Entity::find_by_id(id).one(txn).await?;
+    match canvas {
+        Some(model) => Ok(model),
+        None => Err(DbErr::RecordNotFound("Canvas not found".into())),
+    }
+}
+
+pub async fn update_canvas_transaction(
+    txn: &DatabaseTransaction,
+    canvas: canvas::Model,
+    name: String,
+    description: Option<String>,
+) -> Result<canvas::Model, DbErr> {
+    let mut canvas_active: canvas::ActiveModel = canvas.into();
+    canvas_active.name = Set(name);
+    canvas_active.description = Set(description);
+    canvas_active.updated_at = Set(time_utils::now_utc_into());
+    canvas_active.update(txn).await
+}
+
 pub async fn get_paginated_canvases(
     db: &DatabaseConnection,
     page: u64,

--- a/backend/src/canvas/service.rs
+++ b/backend/src/canvas/service.rs
@@ -1,16 +1,25 @@
+use crate::ai::dto::{CanvasCandidate, CanvasCandidateCell, CanvasOp, CanvasPlan, CanvasPlanChart};
 use crate::canvas::constants::CanvasStatus;
 use crate::canvas::dto;
 use crate::canvas::repository;
+use crate::cell::constants::{
+    AggregateFunction, AxisMinorTickShow, AxisTickShow, CellType, ChartOrientation, ChartType,
+    MetricFormat, SortOrder,
+};
+use crate::cell::dto::{
+    AxisChartContent, ChartContent, CreateCellDto, MetricChartContent, PieChartContent,
+};
 use crate::cell::service as cell_service;
 use crate::common::time_utils;
 use crate::common::{AppState, PaginatedResponse, Pagination};
-use crate::dashboard::service as dashboard_service;
+use crate::dashboard::service::{self as dashboard_service, DashboardChartRequest};
 use crate::entity;
 use crate::notebook::service as notebook_service;
 use axum::extract::Query;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use sea_orm::TransactionTrait;
+use std::collections::HashMap;
 use uuid::Uuid;
 
 pub async fn get_canvas(app_state: AppState, id: Uuid) -> impl IntoResponse {
@@ -112,6 +121,15 @@ pub async fn execute_create_canvas(
     payload: dto::CreateCanvasDto,
 ) -> Result<dto::CreateCanvasResult, sea_orm::DbErr> {
     let txn = app_state.database_connection.begin().await?;
+    let created = create_canvas_transaction(&txn, payload).await?;
+    txn.commit().await?;
+    Ok(created)
+}
+
+async fn create_canvas_transaction(
+    txn: &sea_orm::DatabaseTransaction,
+    payload: dto::CreateCanvasDto,
+) -> Result<dto::CreateCanvasResult, sea_orm::DbErr> {
     let canvas_id = Uuid::new_v4();
     let now = time_utils::now_utc_into();
     let canvas_entity = entity::canvas::Model {
@@ -122,23 +140,22 @@ pub async fn execute_create_canvas(
         created_at: now,
         updated_at: now,
     };
-    let canvas = repository::save_canvas_transaction(&txn, canvas_entity).await?;
+    let canvas = repository::save_canvas_transaction(txn, canvas_entity).await?;
     let notebook = notebook_service::create_notebook_transaction(
-        &txn,
+        txn,
         canvas_id,
         payload.name.clone(),
         payload.description.clone(),
     )
     .await?;
     let dashboard = dashboard_service::create_dashboard_transaction(
-        &txn,
+        txn,
         canvas_id,
         payload.name.clone(),
         payload.description.clone().unwrap_or_default(),
         None,
     )
     .await?;
-    txn.commit().await?;
     Ok(dto::CreateCanvasResult {
         canvas,
         notebook,
@@ -146,18 +163,7 @@ pub async fn execute_create_canvas(
     })
 }
 
-fn chart_content_json(
-    cell_id: Uuid,
-    chart: &crate::ai::dto::CanvasPlanChart,
-) -> Result<String, sea_orm::DbErr> {
-    use crate::cell::constants::{
-        AggregateFunction, AxisMinorTickShow, AxisTickShow, ChartOrientation, ChartType,
-        MetricFormat, SortOrder,
-    };
-    use crate::cell::dto::{
-        AxisChartContent, ChartContent, MetricChartContent, PieChartContent,
-    };
-
+fn chart_content_json(cell_id: Uuid, chart: &CanvasPlanChart) -> Result<String, sea_orm::DbErr> {
     let aggregate_function = chart
         .aggregate_function
         .clone()
@@ -201,99 +207,352 @@ fn chart_content_json(
         .map_err(|_| sea_orm::DbErr::Custom("failed to serialize chart content".into()))
 }
 
-pub async fn generate_canvas_from_plan(
-    app_state: &AppState,
-    connection_id: Uuid,
-    plan: crate::ai::dto::CanvasPlan,
-) -> Result<dto::GeneratedCanvasSummary, sea_orm::DbErr> {
-    use crate::cell::constants::CellType;
-    use crate::cell::dto::CreateCellDto;
-    use crate::dashboard::service::{DashboardChartPlacement, DashboardGridPacker};
+struct CellPair {
+    sql_cell_id: Uuid,
+    chart_cell_id: Option<Uuid>,
+    title: String,
+    sql: String,
+    chart_type: Option<ChartType>,
+}
 
-    let created = execute_create_canvas(
-        app_state,
-        dto::CreateCanvasDto {
-            name: plan.name.clone(),
-            description: plan.description.clone(),
-        },
-    )
-    .await?;
-    let notebook_id = created.notebook.id;
-    let canvas_id = created.canvas.id;
-
-    let mut sql_cell_count = 0;
-    let mut chart_cell_count = 0;
-    let mut placements: Vec<DashboardChartPlacement> = Vec::new();
-    let mut packer = DashboardGridPacker::default();
-    let mut order = 0;
-
-    for plan_cell in plan.cells.iter() {
-        let sql_cell = cell_service::execute_create_cell(
-            app_state,
-            CreateCellDto {
-                notebook_id,
-                connection_id: Some(connection_id),
-                name: Some(plan_cell.title.clone()),
-                content: Some(plan_cell.sql.clone()),
-                display_order: Some(order),
-                cell_type: CellType::Sql,
-            },
-        )
-        .await
-        .map_err(|_| sea_orm::DbErr::Custom("failed to create sql cell".into()))?;
-        sql_cell_count += 1;
-        order += 1;
-
-        if let Some(chart) = &plan_cell.chart {
-            let chart_cell = cell_service::execute_create_cell(
-                app_state,
-                CreateCellDto {
-                    notebook_id,
-                    connection_id: Some(connection_id),
-                    name: Some(plan_cell.title.clone()),
-                    content: Some(chart_content_json(sql_cell.id, chart)?),
-                    display_order: Some(order),
-                    cell_type: CellType::Chart,
-                },
-            )
-            .await
-            .map_err(|_| sea_orm::DbErr::Custom("failed to create chart cell".into()))?;
-            chart_cell_count += 1;
-            order += 1;
-
-            let (x, y, width, height) =
-                packer.place(chart.grid_width_units(), chart.grid_height_units());
-            placements.push(DashboardChartPlacement {
-                cell_id: chart_cell.id,
-                notebook_id,
-                x,
-                y,
-                width,
-                height,
-            });
+fn pair_cells(cells: Vec<entity::cell::Model>) -> Vec<CellPair> {
+    let mut charts: HashMap<Uuid, (Uuid, ChartType)> = HashMap::new();
+    for cell in cells.iter() {
+        if cell.cell_type != CellType::Chart.to_string() {
+            continue;
+        }
+        let Some(content) = cell.content.as_deref() else {
+            continue;
+        };
+        if let Ok(chart) = serde_json::from_str::<ChartContent>(content) {
+            charts.insert(chart.cell_id(), (cell.id, chart.chart_type()));
         }
     }
 
-    let dashboard_charts_count = placements.len() as i32;
-    if !placements.is_empty() {
-        dashboard_service::set_dashboard_layout(
-            app_state,
-            created.dashboard.id,
-            plan.name.clone(),
-            plan.description.clone(),
-            placements,
-        )
-        .await?;
-    }
+    cells
+        .iter()
+        .filter(|cell| cell.cell_type == CellType::Sql.to_string())
+        .map(|cell| {
+            let chart = charts.get(&cell.id);
+            CellPair {
+                sql_cell_id: cell.id,
+                chart_cell_id: chart.map(|(id, _)| *id),
+                title: cell.name.clone().unwrap_or_default(),
+                sql: cell.content.clone().unwrap_or_default(),
+                chart_type: chart.map(|(_, chart_type)| chart_type.clone()),
+            }
+        })
+        .collect()
+}
 
-    Ok(dto::GeneratedCanvasSummary {
-        canvas_id,
-        name: plan.name,
-        description: plan.description,
+pub async fn list_canvas_candidates(
+    app_state: &AppState,
+    canvas_ids: &[Uuid],
+) -> Vec<CanvasCandidate> {
+    let mut candidates = Vec::new();
+    for canvas_id in canvas_ids {
+        let Ok(canvas) = repository::get_canvas(&app_state.database_connection, *canvas_id).await
+        else {
+            continue;
+        };
+        let Ok(notebook) = notebook_service::get_notebook_by_canvas_id(app_state, *canvas_id).await
+        else {
+            continue;
+        };
+        let Ok(cells) =
+            cell_service::get_cells_by_notebook_id_entities(app_state, notebook.id).await
+        else {
+            continue;
+        };
+        candidates.push(CanvasCandidate {
+            id: canvas.id,
+            name: canvas.name,
+            description: canvas.description,
+            cells: pair_cells(cells)
+                .into_iter()
+                .map(|pair| CanvasCandidateCell {
+                    title: pair.title,
+                    sql: pair.sql,
+                    chart_type: pair.chart_type,
+                })
+                .collect(),
+        });
+    }
+    candidates
+}
+
+async fn resolve_existing_canvas(
+    txn: &sea_orm::DatabaseTransaction,
+    canvas_id: Uuid,
+) -> Option<(entity::canvas::Model, Uuid)> {
+    let canvas = repository::get_canvas_transaction(txn, canvas_id)
+        .await
+        .ok()?;
+    let notebook = notebook_service::get_notebook_by_canvas_id_transaction(txn, canvas_id)
+        .await
+        .ok()?;
+    Some((canvas, notebook.id))
+}
+
+fn non_blank(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+struct AppliedChanges {
+    added: i32,
+    updated: i32,
+    removed: i32,
+}
+
+pub async fn apply_canvas_plan(
+    app_state: &AppState,
+    connection_id: Uuid,
+    plan: CanvasPlan,
+    target_canvas_id: Option<Uuid>,
+    ops: Vec<CanvasOp>,
+) -> Result<dto::CanvasChangeSummary, sea_orm::DbErr> {
+    let txn = app_state.database_connection.begin().await?;
+
+    let existing = match target_canvas_id {
+        Some(canvas_id) => resolve_existing_canvas(&txn, canvas_id).await,
+        None => None,
+    };
+    let (canvas, notebook_id, reused) = match existing {
+        Some((canvas, notebook_id)) => (canvas, notebook_id, true),
+        None => {
+            let created = create_canvas_transaction(
+                &txn,
+                dto::CreateCanvasDto {
+                    name: plan.name.clone(),
+                    description: non_blank(&plan.description),
+                },
+            )
+            .await?;
+            (created.canvas, created.notebook.id, false)
+        }
+    };
+
+    let changes = apply_ops(&txn, connection_id, notebook_id, canvas.id, ops).await?;
+    if !reused && changes.added == 0 {
+        return Err(sea_orm::DbErr::Custom(
+            "the canvas plan produced no cells".into(),
+        ));
+    }
+    let name = non_blank(&plan.name).unwrap_or_else(|| canvas.name.clone());
+    let description = non_blank(&plan.description).or_else(|| canvas.description.clone());
+    let canvas =
+        repository::update_canvas_transaction(&txn, canvas, name, description).await?;
+
+    txn.commit().await?;
+
+    let (sql_cell_count, chart_cell_count) =
+        cell_service::get_cell_counts_by_canvas_id(app_state, canvas.id)
+            .await
+            .unwrap_or((0, 0));
+    let dashboard_charts_count =
+        dashboard_service::get_dashboard_charts_count_by_canvas_id(app_state, canvas.id)
+            .await
+            .unwrap_or(0);
+
+    Ok(dto::CanvasChangeSummary {
+        canvas_id: canvas.id,
+        name: canvas.name,
+        description: canvas.description,
+        reused,
+        reasoning: plan.reasoning,
+        cells_added: changes.added,
+        cells_updated: changes.updated,
+        cells_removed: changes.removed,
         sql_cell_count,
         chart_cell_count,
         dashboard_charts_count,
     })
+}
+
+async fn apply_ops(
+    txn: &sea_orm::DatabaseTransaction,
+    connection_id: Uuid,
+    notebook_id: Uuid,
+    canvas_id: Uuid,
+    ops: Vec<CanvasOp>,
+) -> Result<AppliedChanges, sea_orm::DbErr> {
+    let cells = cell_service::get_cells_by_notebook_id_transaction(txn, notebook_id).await?;
+    let mut order = cells.iter().map(|c| c.display_order).max().unwrap_or(-1) + 1;
+    let pairs = pair_cells(cells);
+
+    let mut changes = AppliedChanges {
+        added: 0,
+        updated: 0,
+        removed: 0,
+    };
+    let mut queued: Vec<DashboardChartRequest> = Vec::new();
+    let mut removed_cell_ids: Vec<Uuid> = Vec::new();
+    let mut deleted_indices: std::collections::HashSet<usize> = std::collections::HashSet::new();
+
+    for op in ops {
+        if let CanvasOp::Update { index, .. } | CanvasOp::Delete { index } = &op {
+            if deleted_indices.contains(index) {
+                continue;
+            }
+        }
+        match op {
+            CanvasOp::Create { title, sql, chart } => {
+                let created = create_pair(
+                    txn,
+                    connection_id,
+                    notebook_id,
+                    &mut order,
+                    title,
+                    sql,
+                    chart.as_ref(),
+                )
+                .await?;
+                if let Some(request) = created {
+                    queued.push(request);
+                }
+                changes.added += 1;
+            }
+            CanvasOp::Update {
+                index,
+                title,
+                sql,
+                chart,
+            } => {
+                let Some(pair) = pairs.get(index) else {
+                    continue;
+                };
+                if title.is_some() || sql.is_some() {
+                    cell_service::update_cell_content_transaction(
+                        txn,
+                        pair.sql_cell_id,
+                        title.clone(),
+                        sql,
+                    )
+                    .await?;
+                }
+                if let Some(chart) = chart.as_ref() {
+                    let content = chart_content_json(pair.sql_cell_id, chart)?;
+                    match pair.chart_cell_id {
+                        Some(chart_cell_id) => {
+                            cell_service::update_cell_content_transaction(
+                                txn,
+                                chart_cell_id,
+                                title,
+                                Some(content),
+                            )
+                            .await?;
+                        }
+                        None => {
+                            let chart_cell = create_chart_cell(
+                                txn,
+                                connection_id,
+                                notebook_id,
+                                &mut order,
+                                title.or_else(|| Some(pair.title.clone())),
+                                content,
+                            )
+                            .await?;
+                            queued.push(DashboardChartRequest {
+                                cell_id: chart_cell.id,
+                                notebook_id,
+                                width: chart.grid_width_units(),
+                                height: chart.grid_height_units(),
+                            });
+                        }
+                    }
+                }
+                changes.updated += 1;
+            }
+            CanvasOp::Delete { index } => {
+                let Some(pair) = pairs.get(index) else {
+                    continue;
+                };
+                if let Some(chart_cell_id) = pair.chart_cell_id {
+                    cell_service::delete_cell_transaction(txn, chart_cell_id).await?;
+                    removed_cell_ids.push(chart_cell_id);
+                }
+                cell_service::delete_cell_transaction(txn, pair.sql_cell_id).await?;
+                deleted_indices.insert(index);
+                changes.removed += 1;
+            }
+        }
+    }
+
+    if !queued.is_empty() || !removed_cell_ids.is_empty() {
+        dashboard_service::append_dashboard_charts_transaction(
+            txn,
+            canvas_id,
+            &removed_cell_ids,
+            queued,
+        )
+        .await?;
+    }
+
+    Ok(changes)
+}
+
+async fn create_pair(
+    txn: &sea_orm::DatabaseTransaction,
+    connection_id: Uuid,
+    notebook_id: Uuid,
+    order: &mut i32,
+    title: Option<String>,
+    sql: String,
+    chart: Option<&CanvasPlanChart>,
+) -> Result<Option<DashboardChartRequest>, sea_orm::DbErr> {
+    let sql_cell = cell_service::execute_create_cell_transaction(
+        txn,
+        CreateCellDto {
+            notebook_id,
+            connection_id: Some(connection_id),
+            name: title.clone(),
+            content: Some(sql),
+            display_order: None,
+            cell_type: CellType::Sql,
+        },
+        *order,
+    )
+    .await?;
+    *order += 1;
+
+    let Some(chart) = chart else {
+        return Ok(None);
+    };
+    let content = chart_content_json(sql_cell.id, chart)?;
+    let chart_cell =
+        create_chart_cell(txn, connection_id, notebook_id, order, title, content).await?;
+    Ok(Some(DashboardChartRequest {
+        cell_id: chart_cell.id,
+        notebook_id,
+        width: chart.grid_width_units(),
+        height: chart.grid_height_units(),
+    }))
+}
+
+async fn create_chart_cell(
+    txn: &sea_orm::DatabaseTransaction,
+    connection_id: Uuid,
+    notebook_id: Uuid,
+    order: &mut i32,
+    title: Option<String>,
+    content: String,
+) -> Result<entity::cell::Model, sea_orm::DbErr> {
+    let cell = cell_service::execute_create_cell_transaction(
+        txn,
+        CreateCellDto {
+            notebook_id,
+            connection_id: Some(connection_id),
+            name: title,
+            content: Some(content),
+            display_order: None,
+            cell_type: CellType::Chart,
+        },
+        *order,
+    )
+    .await?;
+    *order += 1;
+    Ok(cell)
 }
 
 pub async fn get_last_modified_canvases(

--- a/backend/src/cell/constants.rs
+++ b/backend/src/cell/constants.rs
@@ -474,6 +474,17 @@ pub enum ChartType {
     Metric,
 }
 
+impl ChartType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ChartType::Bar => "BAR",
+            ChartType::Line => "LINE",
+            ChartType::Pie => "PIE",
+            ChartType::Metric => "METRIC",
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum AggregateFunction {

--- a/backend/src/cell/dto.rs
+++ b/backend/src/cell/dto.rs
@@ -4,6 +4,7 @@ use crate::cell::constants::CellDisplayOrderMovement;
 use crate::cell::constants::CellStatus;
 use crate::cell::constants::CellType;
 use crate::cell::constants::ChartOrientation;
+use crate::cell::constants::ChartType;
 use crate::cell::constants::MetricFormat;
 use crate::cell::constants::SortOrder;
 use crate::common::errors::SophoError;
@@ -23,6 +24,25 @@ pub enum ChartContent {
     Pie(PieChartContent),
     #[serde(rename = "METRIC")]
     Metric(MetricChartContent),
+}
+
+impl ChartContent {
+    pub fn cell_id(&self) -> Uuid {
+        match self {
+            ChartContent::Bar(c) | ChartContent::Line(c) => c.cell_id,
+            ChartContent::Pie(c) => c.cell_id,
+            ChartContent::Metric(c) => c.cell_id,
+        }
+    }
+
+    pub fn chart_type(&self) -> ChartType {
+        match self {
+            ChartContent::Bar(_) => ChartType::Bar,
+            ChartContent::Line(_) => ChartType::Line,
+            ChartContent::Pie(_) => ChartType::Pie,
+            ChartContent::Metric(_) => ChartType::Metric,
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/backend/src/cell/repository.rs
+++ b/backend/src/cell/repository.rs
@@ -49,6 +49,36 @@ pub async fn get_cells_by_notebook_id(
     Ok(cells)
 }
 
+pub async fn get_cells_by_notebook_id_transaction(
+    txn: &DatabaseTransaction,
+    notebook_id: Uuid,
+) -> Result<Vec<cell::Model>, DbErr> {
+    let cells = cell::Entity::find()
+        .filter(cell::Column::NotebookId.eq(notebook_id))
+        .order_by_asc(cell::Column::DisplayOrder)
+        .all(txn)
+        .await?;
+    Ok(cells)
+}
+
+pub async fn update_cell_content_transaction(
+    txn: &DatabaseTransaction,
+    cell_id: Uuid,
+    name: Option<String>,
+    content: Option<String>,
+) -> Result<cell::Model, DbErr> {
+    let cell = get_cell_transaction(txn, cell_id).await?;
+    let mut cell_entity: cell::ActiveModel = cell.into();
+    if let Some(name) = name {
+        cell_entity.name = Set(Some(name));
+    }
+    if let Some(content) = content {
+        cell_entity.content = Set(Some(content));
+    }
+    cell_entity.updated_at = Set(time_utils::now_utc_into());
+    cell_entity.update(txn).await
+}
+
 pub async fn update_cell_display_order(
     db: &DatabaseConnection,
     cell_id: Uuid,

--- a/backend/src/cell/service.rs
+++ b/backend/src/cell/service.rs
@@ -176,6 +176,57 @@ pub async fn execute_create_cell(
     Ok(cell)
 }
 
+pub async fn execute_create_cell_transaction(
+    txn: &sea_orm::DatabaseTransaction,
+    payload: dto::CreateCellDto,
+    display_order: i32,
+) -> Result<entity::cell::Model, sea_orm::DbErr> {
+    let cell_entity = entity::cell::Model {
+        id: Uuid::new_v4(),
+        name: payload.name,
+        content: payload.content,
+        cell_type: payload.cell_type.to_string(),
+        status: CellStatus::Active.to_string(),
+        notebook_id: payload.notebook_id,
+        connection_id: payload.connection_id,
+        display_order,
+        created_at: time_utils::now_utc_into(),
+        updated_at: time_utils::now_utc_into(),
+    };
+    repository::save_cell_transaction(txn, cell_entity).await
+}
+
+pub async fn get_cells_by_notebook_id_entities(
+    app_state: &AppState,
+    notebook_id: Uuid,
+) -> Result<Vec<entity::cell::Model>, sea_orm::DbErr> {
+    repository::get_cells_by_notebook_id(&app_state.database_connection, notebook_id).await
+}
+
+pub async fn get_cells_by_notebook_id_transaction(
+    txn: &sea_orm::DatabaseTransaction,
+    notebook_id: Uuid,
+) -> Result<Vec<entity::cell::Model>, sea_orm::DbErr> {
+    repository::get_cells_by_notebook_id_transaction(txn, notebook_id).await
+}
+
+pub async fn update_cell_content_transaction(
+    txn: &sea_orm::DatabaseTransaction,
+    cell_id: Uuid,
+    name: Option<String>,
+    content: Option<String>,
+) -> Result<entity::cell::Model, sea_orm::DbErr> {
+    repository::update_cell_content_transaction(txn, cell_id, name, content).await
+}
+
+pub async fn delete_cell_transaction(
+    txn: &sea_orm::DatabaseTransaction,
+    cell_id: Uuid,
+) -> Result<(), sea_orm::DbErr> {
+    repository::delete_cell_transaction(txn, cell_id).await?;
+    Ok(())
+}
+
 pub async fn create_cell(app_state: AppState, payload: dto::CreateCellDto) -> impl IntoResponse {
     match execute_create_cell(&app_state, payload).await {
         Ok(cell) => {

--- a/backend/src/common/error_codes.rs
+++ b/backend/src/common/error_codes.rs
@@ -10,6 +10,7 @@ pub enum ErrorCode {
     SyntaxError,
     AiNotLive,
     ConversationBusy,
+    UserMessageLimitReached,
 }
 
 impl ErrorCode {
@@ -24,6 +25,7 @@ impl ErrorCode {
             ErrorCode::SyntaxError => "SYNTAX_ERROR",
             ErrorCode::AiNotLive => "AI_NOT_LIVE",
             ErrorCode::ConversationBusy => "CONVERSATION_BUSY",
+            ErrorCode::UserMessageLimitReached => "USER_MESSAGE_LIMIT_REACHED",
         }
     }
 }
@@ -46,4 +48,5 @@ pub mod codes {
     pub const SYNTAX_ERROR: ErrorCode = ErrorCode::SyntaxError;
     pub const AI_NOT_LIVE: ErrorCode = ErrorCode::AiNotLive;
     pub const CONVERSATION_BUSY: ErrorCode = ErrorCode::ConversationBusy;
+    pub const USER_MESSAGE_LIMIT_REACHED: ErrorCode = ErrorCode::UserMessageLimitReached;
 }

--- a/backend/src/conversational_analytics/conversation/canvas.rs
+++ b/backend/src/conversational_analytics/conversation/canvas.rs
@@ -1,0 +1,111 @@
+use crate::ai::canvas_generation_agent;
+use crate::ai::dto::{CanvasCandidate, ConversationHistory, Event, EventChannels};
+use crate::canvas::dto::CanvasChangeSummary;
+use crate::canvas::service as canvas_service;
+use crate::common::AppState;
+use crate::conversational_analytics::conversation::constants::CONVERSATION_HISTORY_SCAN_MESSAGE_LIMIT;
+use crate::conversational_analytics::message::service as message_service;
+use crate::conversational_analytics::message_content::service as message_content_service;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+pub async fn generate(
+    app_state: &AppState,
+    conversation_id: Uuid,
+    connection_id: Uuid,
+    conversation_history: &ConversationHistory,
+    channels: &EventChannels,
+) -> anyhow::Result<()> {
+    channels.send(Event::GeneratingCanvas).await?;
+
+    let candidates = load(app_state, conversation_id).await;
+    let plan =
+        canvas_generation_agent::execute(app_state, conversation_history, &candidates).await?;
+
+    let target_canvas_id = plan.resolve_target_canvas(&candidates);
+    let target =
+        target_canvas_id.and_then(|id| candidates.iter().find(|candidate| candidate.id == id));
+    let ops = plan.resolve_ops(target);
+    if ops.is_empty() && target_canvas_id.is_none() {
+        anyhow::bail!("the canvas plan contained no usable cells");
+    }
+
+    let summary =
+        canvas_service::apply_canvas_plan(app_state, connection_id, plan, target_canvas_id, ops)
+            .await?;
+    channels.send(generated_event(summary)).await?;
+    Ok(())
+}
+
+fn generated_event(summary: CanvasChangeSummary) -> Event {
+    Event::CanvasGenerated {
+        canvas_id: summary.canvas_id,
+        name: summary.name,
+        description: summary.description,
+        reused: summary.reused,
+        reasoning: summary.reasoning,
+        cells_added: summary.cells_added,
+        cells_updated: summary.cells_updated,
+        cells_removed: summary.cells_removed,
+        sql_cell_count: summary.sql_cell_count,
+        chart_cell_count: summary.chart_cell_count,
+        dashboard_charts_count: summary.dashboard_charts_count,
+    }
+}
+
+async fn load(app_state: &AppState, conversation_id: Uuid) -> Vec<CanvasCandidate> {
+    let canvas_ids = match collect_canvas_ids(app_state, conversation_id).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::error!("conversation canvases: failed to collect canvas ids: {e}");
+            return Vec::new();
+        }
+    };
+    if canvas_ids.is_empty() {
+        return Vec::new();
+    }
+    canvas_service::list_canvas_candidates(app_state, &canvas_ids).await
+}
+
+async fn collect_canvas_ids(
+    app_state: &AppState,
+    conversation_id: Uuid,
+) -> anyhow::Result<Vec<Uuid>> {
+    let mut messages = message_service::list_messages_for_conversation(
+        &app_state.database_connection,
+        conversation_id,
+        Some(CONVERSATION_HISTORY_SCAN_MESSAGE_LIMIT as u64),
+        true,
+    )
+    .await?;
+    messages.sort_by_key(|message| message.sequence_number);
+
+    let message_ids: Vec<Uuid> = messages.iter().map(|message| message.id).collect();
+    let contents = message_content_service::list_message_content_for_messages(
+        &app_state.database_connection,
+        &message_ids,
+    )
+    .await?;
+
+    let mut by_message: HashMap<Uuid, Vec<Uuid>> = HashMap::new();
+    for content in contents.iter() {
+        if let Ok(Event::CanvasGenerated { canvas_id, .. }) =
+            serde_json::from_str::<Event>(&content.content)
+        {
+            by_message
+                .entry(content.conversation_message_id)
+                .or_default()
+                .push(canvas_id);
+        }
+    }
+
+    let mut seen = Vec::new();
+    for message_id in message_ids.iter() {
+        for canvas_id in by_message.remove(message_id).unwrap_or_default() {
+            if !seen.contains(&canvas_id) {
+                seen.push(canvas_id);
+            }
+        }
+    }
+    Ok(seen)
+}

--- a/backend/src/conversational_analytics/conversation/constants.rs
+++ b/backend/src/conversational_analytics/conversation/constants.rs
@@ -14,10 +14,13 @@ pub(super) enum PipelineOutcome {
     AwaitingClarification,
     Rejected,
 }
-pub const CONVERSATION_HISTORY_TURN_LIMIT: usize = 5;
-pub const CONVERSATION_HISTORY_SCAN_TURN_LIMIT: usize = 25;
+pub const MAX_USER_MESSAGES_PER_CONVERSATION: usize = 10;
+
+pub fn user_message_limit_reached(user_message_count: usize) -> bool {
+    user_message_count >= MAX_USER_MESSAGES_PER_CONVERSATION
+}
 pub const CONVERSATION_HISTORY_SCAN_MESSAGE_LIMIT: usize =
-    2 * (CONVERSATION_HISTORY_SCAN_TURN_LIMIT + 1);
+    2 * (MAX_USER_MESSAGES_PER_CONVERSATION + 1);
 
 /// Terminal statuses:
 /// 1. Processed - Successfully processed the user or system message.

--- a/backend/src/conversational_analytics/conversation/controller.rs
+++ b/backend/src/conversational_analytics/conversation/controller.rs
@@ -118,9 +118,11 @@ async fn execute_completion(
                 | ExecuteCompletionError::QuestionTooLong => {
                     (StatusCode::BAD_REQUEST, e.to_string(), None)
                 }
-                ExecuteCompletionError::AiNotLive => {
-                    (StatusCode::FORBIDDEN, e.to_string(), Some(codes::AI_NOT_LIVE.as_str()))
-                }
+                ExecuteCompletionError::AiNotLive => (
+                    StatusCode::FORBIDDEN,
+                    e.to_string(),
+                    Some(codes::AI_NOT_LIVE.as_str()),
+                ),
             };
             let body = match code {
                 Some(c) => serde_json::json!({ "error": error, "code": c }),
@@ -147,7 +149,9 @@ async fn append_user_message(
     Json(payload): Json<dto::AppendUserMessageDto>,
 ) -> impl IntoResponse {
     match service::append_user_message(app_state, conversation_id, payload).await {
-        Ok(response_dto) => (StatusCode::OK, axum::Json(serde_json::json!(response_dto))).into_response(),
+        Ok(response_dto) => {
+            (StatusCode::OK, axum::Json(serde_json::json!(response_dto))).into_response()
+        }
         Err(e) => {
             let (status, error, code) = match &e {
                 AppendUserMessageError::Database(_) => {
@@ -159,13 +163,19 @@ async fn append_user_message(
                     e.to_string(),
                     Some(codes::CONVERSATION_BUSY.as_str()),
                 ),
-                AppendUserMessageError::EmptyQuestion
-                | AppendUserMessageError::QuestionTooLong => {
+                AppendUserMessageError::EmptyQuestion | AppendUserMessageError::QuestionTooLong => {
                     (StatusCode::BAD_REQUEST, e.to_string(), None)
                 }
-                AppendUserMessageError::AiNotLive => {
-                    (StatusCode::FORBIDDEN, e.to_string(), Some(codes::AI_NOT_LIVE.as_str()))
-                }
+                AppendUserMessageError::UserMessageLimitReached => (
+                    StatusCode::CONFLICT,
+                    e.to_string(),
+                    Some(codes::USER_MESSAGE_LIMIT_REACHED.as_str()),
+                ),
+                AppendUserMessageError::AiNotLive => (
+                    StatusCode::FORBIDDEN,
+                    e.to_string(),
+                    Some(codes::AI_NOT_LIVE.as_str()),
+                ),
             };
             let body = match code {
                 Some(c) => serde_json::json!({ "error": error, "code": c }),

--- a/backend/src/conversational_analytics/conversation/dto.rs
+++ b/backend/src/conversational_analytics/conversation/dto.rs
@@ -79,4 +79,5 @@ pub struct ConversationWithMessagesDto {
     pub conversation: ConversationDto,
     pub messages: Vec<ConversationMessageWithContentDto>,
     pub should_execute_completion: bool,
+    pub user_message_limit_reached: bool,
 }

--- a/backend/src/conversational_analytics/conversation/error.rs
+++ b/backend/src/conversational_analytics/conversation/error.rs
@@ -48,6 +48,8 @@ pub enum AppendUserMessageError {
     EmptyQuestion,
     #[error("Question exceeds maximum length")]
     QuestionTooLong,
+    #[error("This conversation has reached its message limit; start a new conversation")]
+    UserMessageLimitReached,
     #[error("AI provider is not configured or not live")]
     AiNotLive,
 }

--- a/backend/src/conversational_analytics/conversation/history.rs
+++ b/backend/src/conversational_analytics/conversation/history.rs
@@ -3,7 +3,7 @@ use crate::ai::dto::{
 };
 use crate::common::AppState;
 use crate::conversational_analytics::conversation::constants::{
-    MessageStatus, CONVERSATION_HISTORY_SCAN_MESSAGE_LIMIT, CONVERSATION_HISTORY_TURN_LIMIT,
+    MessageStatus, CONVERSATION_HISTORY_SCAN_MESSAGE_LIMIT, MAX_USER_MESSAGES_PER_CONVERSATION,
 };
 use crate::conversational_analytics::message::constants::Sender;
 use crate::conversational_analytics::message::dto::ConversationMessageDto;
@@ -41,14 +41,14 @@ pub async fn load(
     let candidates = pair_turns(messages, current_assistant_message_id);
     let selected = ConversationHistory::select_relevant(
         candidates,
-        CONVERSATION_HISTORY_TURN_LIMIT,
+        MAX_USER_MESSAGES_PER_CONVERSATION,
         |candidate| candidate.terminal_status,
     );
     let turns = hydrate(&app_state.database_connection, selected).await;
 
     Ok(ConversationHistory::from_turns(
         turns,
-        CONVERSATION_HISTORY_TURN_LIMIT,
+        MAX_USER_MESSAGES_PER_CONVERSATION,
     ))
 }
 

--- a/backend/src/conversational_analytics/conversation/mod.rs
+++ b/backend/src/conversational_analytics/conversation/mod.rs
@@ -1,3 +1,4 @@
+mod canvas;
 pub mod constants;
 mod controller;
 pub mod dto;

--- a/backend/src/conversational_analytics/conversation/service.rs
+++ b/backend/src/conversational_analytics/conversation/service.rs
@@ -1,3 +1,4 @@
+use super::canvas;
 use super::constants;
 use super::constants::{ConversationStatus, PipelineOutcome};
 use super::dto;
@@ -101,15 +102,20 @@ pub async fn get_conversation(
             ConversationMessageWithContentDto::new(m, content)
         })
         .collect();
-    let should_execute_completion = messages
-        .last()
-        .map(|m| m.message.sender == Sender::Human.to_string())
-        .unwrap_or(false);
+    let should_execute_completion = messages.last().is_some_and(is_human_message);
+    let user_message_limit_reached = constants::user_message_limit_reached(
+        messages.iter().filter(|m| is_human_message(m)).count(),
+    );
     Ok(dto::ConversationWithMessagesDto {
         conversation,
         messages,
         should_execute_completion,
+        user_message_limit_reached,
     })
+}
+
+fn is_human_message(message: &ConversationMessageWithContentDto) -> bool {
+    matches!(message.message.sender.parse::<Sender>(), Ok(Sender::Human))
 }
 
 fn normalize_search(search: Option<String>) -> Option<String> {
@@ -377,6 +383,15 @@ pub async fn append_user_message(
         return Err(AppendUserMessageError::ConversationBusy);
     }
 
+    let user_message_count = message_service::count_user_messages_for_conversation(
+        &app_state.database_connection,
+        conversation_id,
+    )
+    .await?;
+    if constants::user_message_limit_reached(user_message_count as usize) {
+        return Err(AppendUserMessageError::UserMessageLimitReached);
+    }
+
     let segments_json = segment::serialize_segments(&payload.segments);
     let plain_text = segment::plain_text_from_segments(&payload.segments);
     let commands =
@@ -530,6 +545,7 @@ pub async fn execute_completion(
             run_pipeline(
                 &app_state,
                 &connection,
+                conversation_id,
                 &question,
                 &commands,
                 &conversation_history,
@@ -596,6 +612,7 @@ fn resolve_command_decision(
 async fn run_pipeline(
     app_state: &AppState,
     connection: &entity::connection::Model,
+    conversation_id: Uuid,
     question: &str,
     commands: &[Command],
     conversation_history: &ConversationHistory,
@@ -669,24 +686,14 @@ async fn run_pipeline(
             Ok(PipelineOutcome::Completed)
         }
         RouterCode::GenerateCanvas => {
-            channels
-                .send(crate::ai::dto::Event::GeneratingCanvas)
-                .await?;
-            let plan = crate::ai::canvas_generation_agent::execute(app_state, conversation_history)
-                .await?;
-            let summary =
-                crate::canvas::service::generate_canvas_from_plan(app_state, connection.id, plan)
-                    .await?;
-            channels
-                .send(crate::ai::dto::Event::CanvasGenerated {
-                    canvas_id: summary.canvas_id,
-                    name: summary.name,
-                    description: summary.description,
-                    sql_cell_count: summary.sql_cell_count,
-                    chart_cell_count: summary.chart_cell_count,
-                    dashboard_charts_count: summary.dashboard_charts_count,
-                })
-                .await?;
+            canvas::generate(
+                app_state,
+                conversation_id,
+                connection.id,
+                conversation_history,
+                channels,
+            )
+            .await?;
             channels.send(crate::ai::dto::Event::Completed).await?;
             Ok(PipelineOutcome::Completed)
         }

--- a/backend/src/conversational_analytics/message/service.rs
+++ b/backend/src/conversational_analytics/message/service.rs
@@ -1,6 +1,7 @@
 use crate::common::time_utils;
 use crate::common::AppState;
 use crate::conversational_analytics::conversation::error::ConversationError;
+use crate::conversational_analytics::message::constants::Sender;
 use crate::conversational_analytics::message::dto;
 use crate::conversational_analytics::message::repository;
 use crate::entity;
@@ -65,6 +66,19 @@ pub async fn list_messages_for_conversation(
         .collect())
 }
 
+pub async fn count_user_messages_for_conversation(
+    db: &DatabaseConnection,
+    conversation_id: Uuid,
+) -> Result<i64, ConversationError> {
+    let counts = count_messages_by_sender_for_conversations(
+        db,
+        &[conversation_id],
+        &Sender::Human.to_string(),
+    )
+    .await?;
+    Ok(counts.get(&conversation_id).copied().unwrap_or(0))
+}
+
 pub async fn count_messages_by_sender_for_conversations(
     db: &DatabaseConnection,
     conversation_ids: &[Uuid],
@@ -73,8 +87,8 @@ pub async fn count_messages_by_sender_for_conversations(
     if conversation_ids.is_empty() {
         return Ok(HashMap::new());
     }
-    let rows =
-        repository::count_messages_by_sender_for_conversations(db, conversation_ids, sender).await?;
+    let rows = repository::count_messages_by_sender_for_conversations(db, conversation_ids, sender)
+        .await?;
     Ok(rows.into_iter().collect())
 }
 

--- a/backend/src/dashboard/dto.rs
+++ b/backend/src/dashboard/dto.rs
@@ -43,6 +43,10 @@ impl Layout {
         self.cell_id
     }
 
+    pub fn bottom(&self) -> u16 {
+        self.y_position.saturating_add(self.y_size)
+    }
+
     pub fn to_json(layout: Option<Vec<Layout>>) -> Option<Json> {
         layout.map(|layouts| serde_json::to_value(layouts).unwrap_or(serde_json::Value::Null))
     }

--- a/backend/src/dashboard/service.rs
+++ b/backend/src/dashboard/service.rs
@@ -132,13 +132,11 @@ pub async fn execute_update_dashboard(
     repository::update_dashboard(&app_state.database_connection, dashboard_id, payload).await
 }
 
-pub struct DashboardChartPlacement {
+pub struct DashboardChartRequest {
     pub cell_id: Uuid,
     pub notebook_id: Uuid,
-    pub x: u16,
-    pub y: u16,
-    pub width: u16,
-    pub height: u16,
+    pub width: Option<u16>,
+    pub height: Option<u16>,
 }
 
 #[derive(Default)]
@@ -149,6 +147,14 @@ pub struct DashboardGridPacker {
 }
 
 impl DashboardGridPacker {
+    pub fn below(layout: &[Layout]) -> Self {
+        Self {
+            x: 0,
+            y: layout.iter().map(Layout::bottom).max().unwrap_or(0),
+            row_height: 0,
+        }
+    }
+
     pub fn place(&mut self, width: Option<u16>, height: Option<u16>) -> (u16, u16, u16, u16) {
         let width = width
             .unwrap_or(constants::DEFAULT_CHART_WIDTH)
@@ -170,25 +176,33 @@ impl DashboardGridPacker {
     }
 }
 
-pub async fn set_dashboard_layout(
-    app_state: &AppState,
-    dashboard_id: Uuid,
-    name: String,
-    description: Option<String>,
-    charts: Vec<DashboardChartPlacement>,
-) -> Result<entity::dashboard::Model, sea_orm::DbErr> {
-    let layout: Vec<Layout> = charts
-        .into_iter()
-        .map(|c| Layout::new(c.cell_id, c.notebook_id, c.x, c.y, c.width, c.height))
-        .collect();
-    let payload = dto::DashboardDto {
-        id: dashboard_id,
-        name: Some(name),
-        description,
-        layout: Some(layout),
-        status: DashboardStatus::Active,
-    };
-    repository::update_dashboard(&app_state.database_connection, dashboard_id, payload).await
+pub async fn append_dashboard_charts_transaction(
+    txn: &DatabaseTransaction,
+    canvas_id: Uuid,
+    removed_cell_ids: &[Uuid],
+    charts: Vec<DashboardChartRequest>,
+) -> Result<i32, sea_orm::DbErr> {
+    let dashboard = repository::get_dashboard_by_canvas_id_transaction(txn, canvas_id).await?;
+    let mut layout = Layout::from_json(dashboard.layout.clone()).unwrap_or_default();
+    layout.retain(|l| !removed_cell_ids.contains(&l.cell_id()));
+
+    let mut packer = DashboardGridPacker::below(&layout);
+    for chart in charts {
+        let (x, y, width, height) = packer.place(chart.width, chart.height);
+        layout.push(Layout::new(
+            chart.cell_id,
+            chart.notebook_id,
+            x,
+            y,
+            width,
+            height,
+        ));
+    }
+
+    let count = layout.len() as i32;
+    let layout = (!layout.is_empty()).then_some(layout);
+    repository::update_dashboard_layout_transaction(txn, dashboard, layout).await?;
+    Ok(count)
 }
 
 pub async fn delete_dashboard_transaction(

--- a/frontend/src/components/ConversationalAnalytics/AgentTrace/AgentTrace.tsx
+++ b/frontend/src/components/ConversationalAnalytics/AgentTrace/AgentTrace.tsx
@@ -18,6 +18,7 @@ import {
   type RecommendedVisualizationData,
 } from "src/components/ConversationalAnalytics/dto";
 import { CanvasGeneratedCard } from "src/components/ConversationalAnalytics/CanvasGeneratedCard";
+import { CanvasGenerationNote } from "src/components/ConversationalAnalytics/CanvasGenerationNote";
 import { ResultNarration } from "src/components/ConversationalAnalytics/ResultNarration";
 import {
   parseEvent,
@@ -150,7 +151,12 @@ export function AgentTrace({ connectionId, contents }: AgentTraceProps) {
           visualization={visualization}
         />
       )}
-      {canvas && <CanvasGeneratedCard data={canvas} />}
+      {canvas && (
+        <>
+          <CanvasGenerationNote data={canvas} />
+          <CanvasGeneratedCard data={canvas} />
+        </>
+      )}
     </>
   );
 }

--- a/frontend/src/components/ConversationalAnalytics/CanvasGenerationNote/CanvasGenerationNote.tsx
+++ b/frontend/src/components/ConversationalAnalytics/CanvasGenerationNote/CanvasGenerationNote.tsx
@@ -1,0 +1,40 @@
+import { Box, Flex, Text } from "src/components/design-system";
+import type { CanvasGeneratedData } from "src/components/ConversationalAnalytics/dto";
+
+const NOTE_STYLE = { lineHeight: "var(--line-height-relaxed)" };
+
+type CanvasGenerationNoteProps = {
+  data: CanvasGeneratedData;
+};
+
+function changeCounts(data: CanvasGeneratedData): string {
+  return [
+    { count: data.cells_added, label: "added" },
+    { count: data.cells_updated, label: "updated" },
+    { count: data.cells_removed, label: "removed" },
+  ]
+    .filter((part) => (part.count ?? 0) > 0)
+    .map((part) => `${part.count} ${part.label}`)
+    .join(" · ");
+}
+
+export const CanvasGenerationNote = ({ data }: CanvasGenerationNoteProps) => {
+  const reasoning = data.reasoning?.trim();
+  if (!reasoning) return null;
+
+  const outcome = data.reused ? "Updated existing canvas" : "Created a new canvas";
+  const counts = changeCounts(data);
+
+  return (
+    <Box width="100%" paddingX="md" paddingY="sm" sx={NOTE_STYLE}>
+      <Flex direction="column" gap="2xs">
+        <Text fontSize="sm" color="subtle">
+          {counts ? `${outcome} · ${counts}` : `${outcome} · no changes`}
+        </Text>
+        <Text as="p" fontSize="base">
+          {reasoning}
+        </Text>
+      </Flex>
+    </Box>
+  );
+};

--- a/frontend/src/components/ConversationalAnalytics/CanvasGenerationNote/index.tsx
+++ b/frontend/src/components/ConversationalAnalytics/CanvasGenerationNote/index.tsx
@@ -1,0 +1,1 @@
+export { CanvasGenerationNote } from "./CanvasGenerationNote";

--- a/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/ConversationLimitNotice.tsx
+++ b/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/ConversationLimitNotice.tsx
@@ -1,0 +1,36 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router";
+import { Button, Flex, Text } from "src/components/design-system";
+import { APP_ROUTES } from "src/constants/app_routes";
+
+export const ConversationLimitNotice = () => {
+  const navigate = useNavigate();
+
+  const handleStartNewConversation = useCallback(() => {
+    navigate(APP_ROUTES.CONVERSATIONAL_ANALYTICS_ROUTES.INDEX);
+  }, [navigate]);
+
+  return (
+    <Flex
+      direction="column"
+      alignItems="center"
+      gap="sm"
+      paddingY="md"
+      paddingX="md"
+      borderRadius="lg"
+      backgroundColor="grey"
+    >
+      <Text fontSize="sm" color="darkGrey">
+        This conversation has reached its message limit.
+      </Text>
+      <Button
+        label="Start a new conversation"
+        shape="pill"
+        backgroundColor="accent"
+        size="sm"
+        leadingIconName="add"
+        onClick={handleStartNewConversation}
+      />
+    </Flex>
+  );
+};

--- a/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/ExistingConversationPanel.tsx
+++ b/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/ExistingConversationPanel.tsx
@@ -10,6 +10,7 @@ import {
 import { APP_ROUTES } from "src/constants/app_routes";
 import { ConversationActionsMenu } from "src/components/ConversationalAnalytics/ConversationActionsMenu";
 import { Flex, Icon, Text } from "src/components/design-system";
+import { ConversationLimitNotice } from "src/components/ConversationalAnalytics/ExistingConversationPanel/ConversationLimitNotice";
 import { MessageHoverFooter } from "./MessageHoverFooter";
 import {
   getFollowUpDisabledTooltip,
@@ -133,6 +134,7 @@ export const ExistingConversationPanel = () => {
     );
   };
 
+  const conversationFull = !gate.canSend && gate.terminal;
   const composerDisabled = !gate.canSend || appendUserMessage.isPending;
   const composerDisabledTooltip = gate.canSend
     ? undefined
@@ -236,13 +238,17 @@ export const ExistingConversationPanel = () => {
             paddingBottom="md"
             sx={FLEX_SHRINK_STYLE}
           >
-            <MessageComposer
-              ref={composerRef}
-              placeholder={composerPlaceholder}
-              onSubmit={handleSubmit}
-              disabled={composerDisabled}
-              disabledTooltip={composerDisabledTooltip}
-            />
+            {conversationFull ? (
+              <ConversationLimitNotice />
+            ) : (
+              <MessageComposer
+                ref={composerRef}
+                placeholder={composerPlaceholder}
+                onSubmit={handleSubmit}
+                disabled={composerDisabled}
+                disabledTooltip={composerDisabledTooltip}
+              />
+            )}
           </Flex>
         </Flex>
         <ArtifactsPanel />

--- a/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/useCanSendFollowUp.ts
+++ b/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/useCanSendFollowUp.ts
@@ -6,11 +6,12 @@ export type FollowUpGateReason =
   | "ai_not_ready"
   | "streaming"
   | "awaiting_response"
-  | "loading";
+  | "loading"
+  | "conversation_full";
 
 export type FollowUpGate =
   | { canSend: true }
-  | { canSend: false; reason: FollowUpGateReason };
+  | { canSend: false; reason: FollowUpGateReason; terminal: boolean };
 
 export function useCanSendFollowUp(conversationId: string): FollowUpGate {
   const conversationQuery = useConversation(conversationId);
@@ -18,18 +19,21 @@ export function useCanSendFollowUp(conversationId: string): FollowUpGate {
   const { isStreaming } = useConversationStream(conversationId);
 
   if (conversationQuery.isLoading || !conversationQuery.data) {
-    return { canSend: false, reason: "loading" };
+    return { canSend: false, reason: "loading", terminal: false };
+  }
+  if (conversationQuery.data.user_message_limit_reached) {
+    return { canSend: false, reason: "conversation_full", terminal: true };
   }
   if (aiConfiguration?.status !== "live") {
-    return { canSend: false, reason: "ai_not_ready" };
+    return { canSend: false, reason: "ai_not_ready", terminal: false };
   }
   if (isStreaming) {
-    return { canSend: false, reason: "streaming" };
+    return { canSend: false, reason: "streaming", terminal: false };
   }
   const messages = conversationQuery.data.messages;
   const lastMessage = messages[messages.length - 1];
   if (lastMessage && lastMessage.sender === Sender.Human) {
-    return { canSend: false, reason: "awaiting_response" };
+    return { canSend: false, reason: "awaiting_response", terminal: false };
   }
   return { canSend: true };
 }
@@ -44,5 +48,7 @@ export function getFollowUpDisabledTooltip(reason: FollowUpGateReason): string {
       return "Wait for the current response to finish.";
     case "loading":
       return "Loading conversation…";
+    case "conversation_full":
+      return "This conversation has reached its message limit.";
   }
 }

--- a/frontend/src/components/ConversationalAnalytics/StreamingAgentTrace/StreamingAgentTrace.tsx
+++ b/frontend/src/components/ConversationalAnalytics/StreamingAgentTrace/StreamingAgentTrace.tsx
@@ -8,6 +8,7 @@ import {
   type AgentEvent,
 } from "src/components/ConversationalAnalytics/dto";
 import { CanvasGeneratedCard } from "src/components/ConversationalAnalytics/CanvasGeneratedCard";
+import { CanvasGenerationNote } from "src/components/ConversationalAnalytics/CanvasGenerationNote";
 import { ResultNarration } from "src/components/ConversationalAnalytics/ResultNarration";
 import {
   STEP_LABELS,
@@ -107,7 +108,12 @@ export function StreamingAgentTrace({
       )}
       {narration && <ResultNarration text={narration} />}
       {chartData && <QueryResultChart chartData={chartData} />}
-      {canvas && <CanvasGeneratedCard data={canvas} />}
+      {canvas && (
+        <>
+          <CanvasGenerationNote data={canvas} />
+          <CanvasGeneratedCard data={canvas} />
+        </>
+      )}
     </>
   );
 }

--- a/frontend/src/components/ConversationalAnalytics/dto.tsx
+++ b/frontend/src/components/ConversationalAnalytics/dto.tsx
@@ -87,6 +87,7 @@ export type ConversationWithMessagesDto = {
   conversation: ConversationDto;
   messages: ConversationMessageDto[];
   should_execute_completion: boolean;
+  user_message_limit_reached: boolean;
 };
 
 export type SchemaLinkingRelevantColumn = {
@@ -286,6 +287,11 @@ export type CanvasGeneratedData = {
   canvas_id: string;
   name: string;
   description: string | null;
+  reused?: boolean;
+  reasoning?: string;
+  cells_added?: number;
+  cells_updated?: number;
+  cells_removed?: number;
   sql_cell_count: number;
   chart_cell_count: number;
   dashboard_charts_count: number;


### PR DESCRIPTION
- Let the canvas agent decide whether to extend a canvas the conversation already produced or create a new one, instead of creating one per `/canvas`.
- Add `create` / `update` / `delete` cell operations to the canvas plan, addressed by index and applied in a single transaction so a failed run changes nothing.
- Discover a conversation's canvases by replaying persisted `CanvasGenerated` events, then resolve them live against the DB so deleted canvases drop out and hand-added cells are visible to the agent.
- Report reuse, per-turn change counts and the agent's reasoning; reasoning renders as plain text above the canvas card, the card keeps title, description and totals.
- Guard against runaway growth: creates that duplicate an existing query are dropped and logged, and charts missing their required axis/category pair are dropped rather than persisted with empty column names.
- Preserve canvas name and description when the agent returns them blank, so a no-op `/canvas` can no longer wipe them.
- Cap conversations at 10 user messages, surfaced via `user_message_limit_reached` on the conversation response; the composer unmounts and offers a new conversation once reached.
- Widen agent history from 5 turns to the whole conversation, now bounded by that cap.

Closes: #134