### PR TITLE
feat: run selected sql from a notebook cell

### DIFF
--- a/backend/src/cell/service.rs
+++ b/backend/src/cell/service.rs
@@ -720,14 +720,7 @@ pub async fn execute_cell_preview(
         CellType::Sql => {
             let connection_id = match cell.connection_id {
                 Some(id) => id,
-                None => {
-                    return (
-                        StatusCode::PRECONDITION_FAILED,
-                        axum::Json(
-                            serde_json::json!({ "error": "Cell has no connection assigned" }),
-                        ),
-                    );
-                }
+                None => return missing_connection_response(),
             };
             let connection = match fetch_connection(&app_state, connection_id).await {
                 Ok(conn) => conn,
@@ -777,6 +770,17 @@ fn get_database_connection_error_response(
     }
 }
 
+fn missing_connection_response() -> (http::StatusCode, axum::Json<JsonValue>) {
+    (
+        StatusCode::PRECONDITION_FAILED,
+        axum::Json(serde_json::json!({
+            "status": StatusCode::PRECONDITION_FAILED.as_u16(),
+            "code": codes::MISSING_PREREQUISITES.as_str(),
+            "message": "Choose a connection"
+        })),
+    )
+}
+
 async fn execute_sql_with_query(
     connection: &entity::connection::Model,
     query: &str,
@@ -795,16 +799,7 @@ async fn execute_sql_cell(
 ) -> (http::StatusCode, axum::Json<JsonValue>) {
     let connection_id = match cell.connection_id {
         Some(id) => id,
-        None => {
-            return (
-                StatusCode::PRECONDITION_FAILED,
-                axum::Json(serde_json::json!({
-                    "status": StatusCode::PRECONDITION_FAILED.as_u16(),
-                    "code": codes::MISSING_PREREQUISITES.as_str(),
-                    "message": "Choose a connection"
-                })),
-            );
-        }
+        None => return missing_connection_response(),
     };
     let connection = match fetch_connection(app_state, connection_id).await {
         Ok(conn) => conn,

--- a/frontend/src/components/Notebook/Cell/hooks.tsx
+++ b/frontend/src/components/Notebook/Cell/hooks.tsx
@@ -1,65 +1,100 @@
 import { useCallback } from "react";
 import { useExecuteCell, useExecuteCellPreview } from "src/api/cell";
-import { ExecutionState } from "src/components/Notebook/Cell/dto";
+import { CellType, ExecutionState } from "src/components/Notebook/Cell/dto";
+import { getSelectedText } from "src/components/Notebook/CellEditor/editorRegistry";
 import { useStore } from "src/store";
 
-export function useHandleExecuteCell() {
-  const { mutate } = useExecuteCell();
+type ExecutionCallback = (() => void) | null | undefined;
+
+function useStartCellExecution() {
   const setExecutionState = useStore((state) => state.cell.setExecutionState);
 
   return useCallback(
     (
       cellId: string,
-      onSuccessCallback: (() => void) | null = null,
-      onErrorCallback: (() => void) | null = null
+      onSuccessCallback: ExecutionCallback,
+      onErrorCallback: ExecutionCallback
     ) => {
       setExecutionState(cellId, ExecutionState.RUNNING);
-      mutate(cellId, {
+      return {
         onSuccess: () => {
           setExecutionState(cellId, ExecutionState.COMPLETED);
-          if (onSuccessCallback) {
-            onSuccessCallback();
-          }
+          onSuccessCallback?.();
         },
         onError: () => {
           setExecutionState(cellId, ExecutionState.FAILED);
-          if (onErrorCallback) {
-            onErrorCallback();
-          }
+          onErrorCallback?.();
         },
-      });
+      };
     },
-    [mutate, setExecutionState]
+    [setExecutionState]
+  );
+}
+
+export function useHandleExecuteCell() {
+  const { mutate } = useExecuteCell();
+  const startCellExecution = useStartCellExecution();
+
+  return useCallback(
+    (
+      cellId: string,
+      onSuccessCallback: ExecutionCallback = null,
+      onErrorCallback: ExecutionCallback = null
+    ) => {
+      mutate(
+        cellId,
+        startCellExecution(cellId, onSuccessCallback, onErrorCallback)
+      );
+    },
+    [mutate, startCellExecution]
   );
 }
 
 export function useHandleExecuteCellPreview() {
   const { mutate } = useExecuteCellPreview();
-  const setExecutionState = useStore((state) => state.cell.setExecutionState);
+  const startCellExecution = useStartCellExecution();
 
   return useCallback(
     (
       cellId: string,
       content: string,
       cellType: string,
-      onSuccessCallback?: () => void,
-      onErrorCallback?: () => void
+      onSuccessCallback?: ExecutionCallback,
+      onErrorCallback?: ExecutionCallback
     ) => {
-      setExecutionState(cellId, ExecutionState.RUNNING);
       mutate(
         { cellId, content, cellType },
-        {
-          onSuccess: () => {
-            setExecutionState(cellId, ExecutionState.COMPLETED);
-            onSuccessCallback?.();
-          },
-          onError: () => {
-            setExecutionState(cellId, ExecutionState.FAILED);
-            onErrorCallback?.();
-          },
-        }
+        startCellExecution(cellId, onSuccessCallback, onErrorCallback)
       );
     },
-    [mutate, setExecutionState]
+    [mutate, startCellExecution]
+  );
+}
+
+export function useHandleRunCell() {
+  const handleExecuteCell = useHandleExecuteCell();
+  const handleExecuteCellPreview = useHandleExecuteCellPreview();
+
+  return useCallback(
+    (
+      cellId: string,
+      onSuccessCallback: ExecutionCallback = null,
+      onErrorCallback: ExecutionCallback = null
+    ) => {
+      const selectedText = getSelectedText(cellId);
+      if (!selectedText) {
+        handleExecuteCell(cellId, onSuccessCallback, onErrorCallback);
+        return;
+      }
+
+      handleExecuteCellPreview(
+        cellId,
+        selectedText,
+        CellType.SQL,
+        onSuccessCallback,
+        onErrorCallback
+      );
+    },
+    [handleExecuteCell, handleExecuteCellPreview]
   );
 }

--- a/frontend/src/components/Notebook/Cell/index.tsx
+++ b/frontend/src/components/Notebook/Cell/index.tsx
@@ -14,4 +14,5 @@ export {
 export {
   useHandleExecuteCell,
   useHandleExecuteCellPreview,
+  useHandleRunCell,
 } from "src/components/Notebook/Cell/hooks";

--- a/frontend/src/components/Notebook/CellEditor/CellEditor.tsx
+++ b/frontend/src/components/Notebook/CellEditor/CellEditor.tsx
@@ -34,6 +34,10 @@ import CellEditorStyles from "src/components/Notebook/CellEditor/CellEditor.modu
 import { NOTEBOOK_CELL_KEYBOARD_SHORTCUTS } from "src/utils/keyboard_shortcuts";
 import { KeyBinding } from "@codemirror/view";
 import { lintKeymap } from "@codemirror/lint";
+import {
+  registerEditorView,
+  unregisterEditorView,
+} from "src/components/Notebook/CellEditor/editorRegistry";
 import { theme } from "./theme";
 
 /**
@@ -141,10 +145,12 @@ export function CellEditor({ cellId }: { cellId: string }) {
         state: state,
       });
       viewRef.current = view;
+      registerEditorView(cellId, view);
     }
 
     return () => {
       if (viewRef.current) {
+        unregisterEditorView(cellId, viewRef.current);
         viewRef.current.destroy();
         viewRef.current = null;
       }

--- a/frontend/src/components/Notebook/CellEditor/editorRegistry.ts
+++ b/frontend/src/components/Notebook/CellEditor/editorRegistry.ts
@@ -1,0 +1,24 @@
+import { EditorView } from "@codemirror/view";
+
+const editorViews = new Map<string, EditorView>();
+
+export function registerEditorView(cellId: string, view: EditorView) {
+  editorViews.set(cellId, view);
+}
+
+export function unregisterEditorView(cellId: string, view: EditorView) {
+  if (editorViews.get(cellId) === view) {
+    editorViews.delete(cellId);
+  }
+}
+
+export function getSelectedText(cellId: string): string | null {
+  const view = editorViews.get(cellId);
+  if (!view) return null;
+
+  const { from, to } = view.state.selection.main;
+  if (from === to) return null;
+
+  const selectedText = view.state.sliceDoc(from, to).trim();
+  return selectedText.length > 0 ? selectedText : null;
+}

--- a/frontend/src/components/Notebook/CellToolbar/CellToolbar.tsx
+++ b/frontend/src/components/Notebook/CellToolbar/CellToolbar.tsx
@@ -6,7 +6,8 @@ import { useConnections } from "src/api/connection";
 import { Select } from "src/components/design-system/Select";
 import { useUpdateCell, useCell, useClearCellOutput } from "src/api/cell";
 import { useCallback, useEffect, useState } from "react";
-import { useHandleExecuteCell } from "src/components/Notebook/Cell";
+import { useHandleRunCell } from "src/components/Notebook/Cell";
+import { getSelectedText } from "src/components/Notebook/CellEditor/editorRegistry";
 import {
   useExecutionPhase,
   ExecutionPhase,
@@ -19,6 +20,17 @@ import {
   getShortcutDisplayString,
 } from "src/utils/keyboard_shortcuts";
 
+function ExecuteTooltipContent({ cellId }: { cellId: string }) {
+  return (
+    <Flex direction="row" alignItems="center" gap="md">
+      <span>{getSelectedText(cellId) ? "Run selection" : "Execute cell"}</span>
+      <Kbd>
+        {getShortcutDisplayString(KEYBOARD_SHORTCUTS.EXECUTE_NOTEBOOK_CELL)}
+      </Kbd>
+    </Flex>
+  );
+}
+
 export function CellToolbar({ cellId }: { cellId: string }) {
   const clearCellOutput = useClearCellOutput();
   const query = useConnections();
@@ -30,7 +42,7 @@ export function CellToolbar({ cellId }: { cellId: string }) {
   const [initialValue, setInitialValue] = useState<
     { label: string; value: string } | undefined
   >(undefined);
-  const handleExecuteCell = useHandleExecuteCell();
+  const handleRunCell = useHandleRunCell();
   const { isRunning, phase, startedAt } = useExecutionPhase(cellId);
   const showElapsed = isAtLeast(phase, ExecutionPhase.EXTENDED);
 
@@ -86,8 +98,8 @@ export function CellToolbar({ cellId }: { cellId: string }) {
   );
 
   const handleExecute = useCallback(() => {
-    handleExecuteCell(cellId);
-  }, [cellId, handleExecuteCell]);
+    handleRunCell(cellId);
+  }, [cellId, handleRunCell]);
 
   const handleClearOutput = useCallback(() => {
     clearCellOutput(cellId);
@@ -167,16 +179,7 @@ export function CellToolbar({ cellId }: { cellId: string }) {
                 iconColor="green"
                 onClick={handleExecute}
                 tooltip={{
-                  content: (
-                    <Flex direction="row" alignItems="center" gap="md">
-                      <span>Execute cell</span>
-                      <Kbd>
-                        {getShortcutDisplayString(
-                          KEYBOARD_SHORTCUTS.EXECUTE_NOTEBOOK_CELL
-                        )}
-                      </Kbd>
-                    </Flex>
-                  ),
+                  content: <ExecuteTooltipContent cellId={cellId} />,
                 }}
               />
             )}

--- a/frontend/src/components/Notebook/Notebook.tsx
+++ b/frontend/src/components/Notebook/Notebook.tsx
@@ -6,7 +6,7 @@ import { useStore } from "src/store";
 import { useNotebook } from "src/api/notebook/queries";
 import { CellType, ExecutionState } from "src/components/Notebook/Cell/dto";
 import { KEYBOARD_SHORTCUTS } from "src/utils/keyboard_shortcuts";
-import { useHandleExecuteCell } from "src/components/Notebook/Cell";
+import { useHandleRunCell } from "src/components/Notebook/Cell";
 import { useScrollToCellFromUrl } from "src/components/Notebook/hooks";
 import { useKeyboardShortcut } from "src/utils/keyboard_shortcuts/hooks";
 import { Flex } from "src/components/design-system/Flex/Flex";
@@ -25,7 +25,7 @@ export function Notebook() {
   const canvasId = params.id || "";
   const activeNotebookId = useStore((state) => state.canvas.activeNotebookId);
   const query = useNotebook(activeNotebookId);
-  const handleExecuteCell = useHandleExecuteCell();
+  const handleRunCell = useHandleRunCell();
   const notebookRef = useRef<HTMLDivElement>(null);
   const createCellMutation = useCreateCell();
   const deleteCellMutation = useDeleteCell(
@@ -43,8 +43,8 @@ export function Notebook() {
 
   const handleExecute = useCallback(() => {
     const activeCellId = useStore.getState().notebook.activeCellId;
-    handleExecuteCell(activeCellId);
-  }, [handleExecuteCell]);
+    handleRunCell(activeCellId);
+  }, [handleRunCell]);
 
   const handleClearOutput = useCallback(() => {
     const activeCellId = useStore.getState().notebook.activeCellId;


### PR DESCRIPTION
- Run only the highlighted fragment of a SQL cell when a selection exists, otherwise run the whole cell.
- Apply to both the toolbar run button and the Cmd+Enter shortcut.
- Register CodeMirror editor views per cell so the selection is read at execution time.
- Switch the run button tooltip to `Run selection` while a selection is active.
- Return the same `MISSING_PREREQUISITES` error shape from the preview execution path as the normal one.
- Deduplicate the cell execution state handling shared by the execute and preview hooks.

Closes: #152