### PR TITLE
chore(frontend): stack canvas create dialog fields vertically

### DIFF
--- a/frontend/src/components/Canvases/CanvasCreateDialog/CanvasCreateDialog.module.css
+++ b/frontend/src/components/Canvases/CanvasCreateDialog/CanvasCreateDialog.module.css
@@ -8,6 +8,10 @@
   width: 30%;
 }
 
+.formFieldsSingleColumn {
+  grid-template-columns: 1fr;
+}
+
 .formFieldContainer {
   display: flex;
   flex-direction: row;

--- a/frontend/src/components/Canvases/CanvasCreateDialog/CanvasCreateDialog.tsx
+++ b/frontend/src/components/Canvases/CanvasCreateDialog/CanvasCreateDialog.tsx
@@ -76,7 +76,7 @@ export function CanvasCreateDialog() {
   const dialogContent = (
     <Form defaultValues={DEFAULT_FORM_VALUES} onSubmit={onSubmitCallback}>
       <Form.ErrorBanner />
-      <Form.Fields>
+      <Form.Fields className={styles.formFieldsSingleColumn}>
         <Form.Field
           name="name"
           required


### PR DESCRIPTION
- Stack the Name and Description fields vertically in the new canvas dialog.
- Scoped to the dialog via its own CSS module; the generic `Form` component is unchanged.