### PR TITLE
fix(frontend): keep sql result row number column width constant

### DIFF
--- a/frontend/src/components/design-system/DataTable/DataTable.module.css
+++ b/frontend/src/components/design-system/DataTable/DataTable.module.css
@@ -32,6 +32,16 @@
   text-overflow: ellipsis;
 }
 
+/*
+ * The table is `table-layout: auto` at `width: 100%`, so leftover space is shared
+ * proportionally between every px-width column. A percentage width opts the column
+ * out of that distribution and collapses it onto its min-width instead.
+ */
+.fixedWidthCell {
+  width: 1%;
+  box-sizing: border-box;
+}
+
 .tableHeaderCell {
   font-family: var(--font-family-primary);
   color: var(--color-grey-800);

--- a/frontend/src/components/design-system/DataTable/components/TableHeader.tsx
+++ b/frontend/src/components/design-system/DataTable/components/TableHeader.tsx
@@ -1,6 +1,6 @@
 import { flexRender, Table, HeaderGroup } from "@tanstack/react-table";
 import { ColumnConfig } from "src/components/design-system/DataTable/types";
-import { getHeaderAlignmentClass, getHeaderJustifyContent } from "src/components/design-system/DataTable/utils";
+import { getHeaderAlignmentClass, getHeaderJustifyContent, getColumnWidthStyle } from "src/components/design-system/DataTable/utils";
 import { Icon } from "src/components/design-system/Icon/Icon";
 import { Flex } from "src/components/design-system/Flex";
 import styles from "src/components/design-system/DataTable/DataTable.module.css";
@@ -44,10 +44,8 @@ export function TableHeader<T>({
               <th
                 key={header.id}
                 colSpan={header.colSpan}
-                className={`${styles.tableHeaderCell} ${tableHeaderCellStyle || ""} ${isFirst && tableFirstHeaderCellStyle ? tableFirstHeaderCellStyle : ""} ${isLast && tableLastHeaderCellStyle ? tableLastHeaderCellStyle : ""} ${isHovered ? styles.tableHeaderCellHovered : ""} ${alignmentClass}`}
-                style={{
-                  width: header.getSize(),
-                }}
+                className={`${styles.tableHeaderCell} ${tableHeaderCellStyle || ""} ${isFirst && tableFirstHeaderCellStyle ? tableFirstHeaderCellStyle : ""} ${isLast && tableLastHeaderCellStyle ? tableLastHeaderCellStyle : ""} ${isHovered ? styles.tableHeaderCellHovered : ""} ${alignmentClass} ${columnConfig?.fixedWidth !== undefined ? styles.fixedWidthCell : ""}`}
+                style={getColumnWidthStyle(columnConfig, header.getSize())}
               >
                 {header.isPlaceholder ? null : (
                   <Flex
@@ -116,7 +114,7 @@ export function TableHeader<T>({
                     })()}
                   </Flex>
                 )}
-                {table.options.enableColumnResizing && (
+                {table.options.enableColumnResizing && header.column.getCanResize() && (
                   <div
                     onDoubleClick={() => header.column.resetSize()}
                     onMouseDown={(e) => {

--- a/frontend/src/components/design-system/DataTable/components/TableRow.tsx
+++ b/frontend/src/components/design-system/DataTable/components/TableRow.tsx
@@ -3,6 +3,7 @@ import { ColumnConfig } from "src/components/design-system/DataTable/types";
 import {
   getAlignmentClass,
   getFontClass,
+  getColumnWidthStyle,
 } from "src/components/design-system/DataTable/utils";
 import styles from "src/components/design-system/DataTable/DataTable.module.css";
 
@@ -45,10 +46,8 @@ export function TableRow<T>({
         return (
           <td
             key={cell.id}
-            className={`${styles.tableDataCell} ${tableDataCellStyle} ${isHovered ? styles.tableDataCellHovered : ""} ${alignmentClass} ${fontClass}`}
-            style={{
-              width: cell.column.getSize(),
-            }}
+            className={`${styles.tableDataCell} ${tableDataCellStyle} ${isHovered ? styles.tableDataCellHovered : ""} ${alignmentClass} ${fontClass} ${columnConfig?.fixedWidth !== undefined ? styles.fixedWidthCell : ""}`}
+            style={getColumnWidthStyle(columnConfig, cell.column.getSize())}
           >
             {flexRender(cell.column.columnDef.cell, cell.getContext())}
           </td>

--- a/frontend/src/components/design-system/DataTable/hooks/useDataTable.tsx
+++ b/frontend/src/components/design-system/DataTable/hooks/useDataTable.tsx
@@ -95,8 +95,7 @@ export function useDataTable<T>({
             <Text color="darkGrey">{getDisplayRowNumber(table, row)}</Text>
           </Flex>
         ),
-        size: ROW_NUMBER_COLUMN_WIDTH,
-        minSize: ROW_NUMBER_COLUMN_WIDTH,
+        fixedWidth: ROW_NUMBER_COLUMN_WIDTH,
       });
     }
 
@@ -137,6 +136,7 @@ export function useDataTable<T>({
         size: col.size,
         minSize: col.minSize,
         maxSize: col.maxSize,
+        enableResizing: col.fixedWidth === undefined,
       };
 
       if (col.type === "accessor" && col.accessor) {

--- a/frontend/src/components/design-system/DataTable/types.ts
+++ b/frontend/src/components/design-system/DataTable/types.ts
@@ -13,6 +13,7 @@ export type ColumnConfig<T> = {
   size?: number;
   minSize?: number;
   maxSize?: number;
+  fixedWidth?: number;
   type: "accessor" | "display";
   cell?: (props: CellContext<T, unknown>) => React.ReactNode;
   accessor?: keyof T;

--- a/frontend/src/components/design-system/DataTable/utils.tsx
+++ b/frontend/src/components/design-system/DataTable/utils.tsx
@@ -16,6 +16,7 @@ import { Pagination } from "src/components/design-system/Pagination";
 import {
   TableType,
   PaginationConfig,
+  ColumnConfig,
 } from "src/components/design-system/DataTable/types";
 import styles from "src/components/design-system/DataTable/DataTable.module.css";
 
@@ -96,6 +97,20 @@ export function getFontClass(dataType: ColumnDataType | undefined): string {
   }
 
   return "";
+}
+
+export function getColumnWidthStyle<T>(
+  columnConfig: ColumnConfig<T> | undefined,
+  resolvedColumnSize: number
+): React.CSSProperties {
+  if (columnConfig?.fixedWidth === undefined) {
+    return { width: resolvedColumnSize };
+  }
+
+  return {
+    minWidth: columnConfig.fixedWidth,
+    maxWidth: columnConfig.fixedWidth,
+  };
 }
 
 export function getDisplayRowNumber<T>(table: Table<T>, row: Row<T>): number {


### PR DESCRIPTION
- Fix row number column expanding to absorb leftover table width instead of staying fixed.
- Add `fixedWidth` to `ColumnConfig` for columns that must not participate in the table's leftover-space distribution.
- Disable column resizing and the resize handle for fixed width columns.

Refs: #156