### PR TITLE
feat(frontend): make slash commands discoverable

### DIFF
--- a/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/ExistingConversationPanel.tsx
+++ b/frontend/src/components/ConversationalAnalytics/ExistingConversationPanel/ExistingConversationPanel.tsx
@@ -26,6 +26,7 @@ import {
   useStartStream,
 } from "src/components/ConversationalAnalytics/ConversationStreamContext";
 import type { MessageComposerHandle } from "src/components/ConversationalAnalytics/MessageComposer";
+import { SLASH_COMMANDS } from "src/constants/slash_commands";
 import type { MessageSegment } from "src/api/conversational_analytics/queries";
 import { extractFollowUpQuestions } from "src/components/ConversationalAnalytics/dto";
 import {
@@ -151,7 +152,7 @@ export const ExistingConversationPanel = () => {
   const composerPlaceholder =
     lastAssistantStatus === MessageStatus.AwaitingClarification
       ? "Answer the clarifying question…"
-      : "Ask something else...";
+      : "Ask a follow-up, or type / for commands";
 
   const messagesToRender = useMemo(() => {
     const all = conversationQuery.data?.messages ?? [];
@@ -247,6 +248,7 @@ export const ExistingConversationPanel = () => {
                 onSubmit={handleSubmit}
                 disabled={composerDisabled}
                 disabledTooltip={composerDisabledTooltip}
+                availableCommands={SLASH_COMMANDS}
               />
             )}
           </Flex>

--- a/frontend/src/components/ConversationalAnalytics/MessageComposer/MessageComposer.tsx
+++ b/frontend/src/components/ConversationalAnalytics/MessageComposer/MessageComposer.tsx
@@ -36,11 +36,14 @@ import {
   SlashCommandExtension,
   isSlashSuggestionActive,
 } from "./SlashCommandExtension";
+import { SlashCommandTrigger } from "./SlashCommandTrigger";
 import type { MessageSegment } from "src/components/ConversationalAnalytics/dto";
+import type { SlashCommand } from "src/constants/slash_commands";
 import styles from "./MessageComposer.module.css";
 
 export type MessageComposerHandle = {
   setText: (text: string) => void;
+  insertCommand: (commandName: string) => void;
 };
 
 type MessageComposerProps = {
@@ -50,6 +53,7 @@ type MessageComposerProps = {
   disabledTooltip?: string;
   enabledTooltip?: string;
   slotLeft?: ReactNode;
+  availableCommands: SlashCommand[];
   ref?: Ref<MessageComposerHandle>;
 };
 
@@ -77,6 +81,7 @@ export function MessageComposer({
   disabledTooltip,
   enabledTooltip = "Send",
   slotLeft,
+  availableCommands,
   ref,
 }: MessageComposerProps) {
   const editor = useEditor({
@@ -103,7 +108,7 @@ export function MessageComposer({
       TrailingNode,
       Underline,
       UndoRedo,
-      SlashCommandExtension,
+      SlashCommandExtension.configure({ availableCommands }),
       Placeholder.configure({
         placeholder,
         emptyEditorClass: "is-editor-empty",
@@ -116,7 +121,8 @@ export function MessageComposer({
       },
       handleKeyDown: (_view, event) => {
         if (event.key === "Enter" && !event.shiftKey) {
-          if (editor && isSlashSuggestionActive(editor)) return false;
+          if (editor && isSlashSuggestionActive(editor, availableCommands))
+            return false;
           event.preventDefault();
           if (disabled || !editor) return true;
           const segments = extractSegments(editor);
@@ -140,11 +146,41 @@ export function MessageComposer({
         editor.commands.setContent(text);
         editor.commands.focus("end");
       },
+      insertCommand: (commandName: string) => {
+        if (!editor) return;
+        editor
+          .chain()
+          .focus("end")
+          .insertContent([
+            {
+              type: EditorNodeName.SlashCommand,
+              attrs: { commandName },
+            },
+            { type: "text", text: " " },
+          ])
+          .run();
+      },
     }),
     [editor],
   );
 
   const providerValue = useMemo(() => ({ editor }), [editor]);
+
+  const handleOpenSlashMenu = () => {
+    if (disabled || !editor) return;
+    const { from } = editor.state.selection;
+    const characterBeforeCaret = editor.state.doc.textBetween(
+      Math.max(0, from - 1),
+      from,
+    );
+    const needsSeparatingSpace =
+      characterBeforeCaret !== "" && characterBeforeCaret !== " ";
+    editor
+      .chain()
+      .focus()
+      .insertContent(needsSeparatingSpace ? " /" : "/")
+      .run();
+  };
 
   const handleClickSend = () => {
     if (disabled || !editor) return;
@@ -179,7 +215,15 @@ export function MessageComposer({
             backgroundColor: "var(--color-background)",
           }}
         >
-          {slotLeft}
+          <Flex alignItems="center" gap="xs">
+            {slotLeft}
+            {availableCommands.length > 0 && (
+              <SlashCommandTrigger
+                onClick={handleOpenSlashMenu}
+                disabled={disabled}
+              />
+            )}
+          </Flex>
           <Box sx={{ opacity: disabled ? 0.5 : 1, marginLeft: "auto" }}>
             <IconButton
               type="arrow_up"

--- a/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandExtension.tsx
+++ b/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandExtension.tsx
@@ -12,29 +12,39 @@ import {
   SlashCommandList,
   type SlashCommandListHandle,
 } from "./SlashCommandList";
+import {
+  findMatchingSlashCommands,
+  type SlashCommand,
+} from "src/constants/slash_commands";
 
 export enum EditorNodeName {
   SlashCommand = "slashCommand",
 }
 
-export type SlashCommand = { name: string; description: string };
-
-export const SLASH_COMMANDS: SlashCommand[] = [
-  { name: "canvas", description: "Generate canvas for the conversation" },
-];
+export type SlashCommandExtensionOptions = {
+  availableCommands: SlashCommand[];
+};
 
 const slashCommandPluginKey = new PluginKey(EditorNodeName.SlashCommand);
 
-export const isSlashSuggestionActive = (editor: Editor): boolean =>
-  slashCommandPluginKey.getState(editor.state)?.active ?? false;
+export const isSlashSuggestionActive = (
+  editor: Editor,
+  availableCommands: SlashCommand[],
+): boolean => {
+  const suggestionState = slashCommandPluginKey.getState(editor.state);
+  if (!suggestionState?.active) return false;
+  return (
+    findMatchingSlashCommands(availableCommands, suggestionState.query).length >
+    0
+  );
+};
 
-const suggestion: Omit<SuggestionOptions<SlashCommand>, "editor"> = {
+const buildSuggestion = (
+  availableCommands: SlashCommand[],
+): Omit<SuggestionOptions<SlashCommand>, "editor"> => ({
   char: "/",
   pluginKey: slashCommandPluginKey,
-  items: ({ query }) =>
-    SLASH_COMMANDS.filter((command) =>
-      command.name.toLowerCase().startsWith(query.toLowerCase()),
-    ),
+  items: ({ query }) => findMatchingSlashCommands(availableCommands, query),
   command: ({ editor, range, props }) => {
     editor
       .chain()
@@ -84,14 +94,18 @@ const suggestion: Omit<SuggestionOptions<SlashCommand>, "editor"> = {
       },
     };
   },
-};
+});
 
-export const SlashCommandExtension = Node.create({
+export const SlashCommandExtension = Node.create<SlashCommandExtensionOptions>({
   name: EditorNodeName.SlashCommand,
   group: "inline",
   inline: true,
   atom: true,
   selectable: true,
+
+  addOptions() {
+    return { availableCommands: [] };
+  },
 
   addAttributes() {
     return {
@@ -118,6 +132,12 @@ export const SlashCommandExtension = Node.create({
   },
 
   addProseMirrorPlugins() {
-    return [Suggestion({ editor: this.editor, ...suggestion })];
+    if (this.options.availableCommands.length === 0) return [];
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...buildSuggestion(this.options.availableCommands),
+      }),
+    ];
   },
 });

--- a/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandList.tsx
+++ b/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useImperativeHandle, useState, type Ref } from "react";
-import { DropdownMenu } from "src/components/design-system";
-import type { SlashCommand } from "./SlashCommandExtension";
+import { Box, DropdownMenu, Text } from "src/components/design-system";
+import type { SlashCommand } from "src/constants/slash_commands";
 
 export type SlashCommandListHandle = {
   onKeyDown: (event: KeyboardEvent) => boolean;
@@ -48,7 +48,7 @@ export function SlashCommandList({
   }));
 
   const rect = clientRect?.();
-  if (items.length === 0 || !rect) return null;
+  if (!rect) return null;
 
   return (
     <DropdownMenu open modal={false}>
@@ -71,15 +71,23 @@ export function SlashCommandList({
         sideOffset={4}
         preventAutoFocus
       >
-        {items.map((item, index) => (
-          <DropdownMenu.ItemWithDescription
-            key={item.name}
-            label={`/${item.name}`}
-            description={item.description}
-            highlighted={index === selectedIndex}
-            onClick={() => selectItem(index)}
-          />
-        ))}
+        {items.length === 0 ? (
+          <Box paddingX="md" paddingY="sm">
+            <Text as="span" color="subtle" fontSize="sm">
+              No matching commands
+            </Text>
+          </Box>
+        ) : (
+          items.map((item, index) => (
+            <DropdownMenu.ItemWithDescription
+              key={item.name}
+              label={`/${item.name}`}
+              description={item.description}
+              highlighted={index === selectedIndex}
+              onClick={() => selectItem(index)}
+            />
+          ))
+        )}
       </DropdownMenu.Content>
     </DropdownMenu>
   );

--- a/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandTrigger.tsx
+++ b/frontend/src/components/ConversationalAnalytics/MessageComposer/SlashCommandTrigger.tsx
@@ -1,0 +1,24 @@
+import { Button, ToolTip } from "src/components/design-system";
+
+type SlashCommandTriggerProps = {
+  onClick: () => void;
+  disabled: boolean;
+};
+
+export function SlashCommandTrigger({
+  onClick,
+  disabled,
+}: SlashCommandTriggerProps) {
+  return (
+    <ToolTip messageElement="Insert Command" tooltipSide="top">
+      <Button
+        label="/ Commands"
+        shape="pill"
+        backgroundColor="ghost"
+        size="sm"
+        onClick={onClick}
+        disabled={disabled}
+      />
+    </ToolTip>
+  );
+}

--- a/frontend/src/components/ConversationalAnalytics/NewConversationPanel/NewConversationPanel.tsx
+++ b/frontend/src/components/ConversationalAnalytics/NewConversationPanel/NewConversationPanel.tsx
@@ -11,6 +11,8 @@ import {
 } from "src/components/ConversationalAnalytics/MessageComposer";
 import type { MessageSegment } from "src/api/conversational_analytics/queries";
 import { SuggestedQuestions } from "src/components/ConversationalAnalytics/NewConversationPanel/SuggestedQuestions";
+import { SlashCommandSuggestionList } from "src/components/ConversationalAnalytics/SlashCommandSuggestionList";
+import { SLASH_COMMANDS_FOR_FIRST_MESSAGE } from "src/constants/slash_commands";
 import styles from "./NewConversationPanel.module.css";
 
 export function NewConversationPanel() {
@@ -69,10 +71,15 @@ export function NewConversationPanel() {
         </Heading>
         <MessageComposer
           ref={composerRef}
-          placeholder="Hi, how can I help you today ?"
+          placeholder={
+            SLASH_COMMANDS_FOR_FIRST_MESSAGE.length > 0
+              ? "Ask anything, or type / for commands"
+              : "Ask anything about your data"
+          }
           onSubmit={handleSubmit}
           disabled={disabled}
           disabledTooltip={disabledTooltip}
+          availableCommands={SLASH_COMMANDS_FOR_FIRST_MESSAGE}
           slotLeft={
             <Select
               value={selectedConnectionId}
@@ -90,6 +97,12 @@ export function NewConversationPanel() {
                 ))}
               </Select.Content>
             </Select>
+          }
+        />
+        <SlashCommandSuggestionList
+          commands={SLASH_COMMANDS_FOR_FIRST_MESSAGE}
+          onPick={(commandName) =>
+            composerRef.current?.insertCommand(commandName)
           }
         />
         <SuggestedQuestions

--- a/frontend/src/components/ConversationalAnalytics/SlashCommandSuggestionList.module.css
+++ b/frontend/src/components/ConversationalAnalytics/SlashCommandSuggestionList.module.css
@@ -1,0 +1,3 @@
+.item:hover {
+  background-color: var(--color-grey-200);
+}

--- a/frontend/src/components/ConversationalAnalytics/SlashCommandSuggestionList.tsx
+++ b/frontend/src/components/ConversationalAnalytics/SlashCommandSuggestionList.tsx
@@ -1,0 +1,50 @@
+import { Badge, Flex, Text } from "src/components/design-system";
+import type { SlashCommand } from "src/constants/slash_commands";
+import styles from "./SlashCommandSuggestionList.module.css";
+
+type SlashCommandSuggestionListProps = {
+  commands: SlashCommand[];
+  onPick: (commandName: string) => void;
+};
+
+export function SlashCommandSuggestionList({
+  commands,
+  onPick,
+}: SlashCommandSuggestionListProps) {
+  if (!commands.length) return null;
+
+  return (
+    <Flex
+      as="ul"
+      gap="xs"
+      alignItems="center"
+      sx={{ listStyle: "none", margin: 0, padding: 0, flexWrap: "wrap" }}
+    >
+      {commands.map(({ name, description }) => (
+        <Flex
+          as="li"
+          key={name}
+          gap="xs"
+          paddingX="md"
+          paddingY="sm"
+          borderRadius="lg"
+          alignItems="center"
+          onClick={() => onPick(name)}
+          className={styles.item}
+          sx={{
+            cursor: "pointer",
+            border:
+              "var(--border-width-medium) dashed var(--border-color-light)",
+          }}
+        >
+          <Badge variant="command" shape="rounded" size="sm">
+            {`/${name}`}
+          </Badge>
+          <Text as="span" color="subtle" fontSize="sm">
+            {description}
+          </Text>
+        </Flex>
+      ))}
+    </Flex>
+  );
+}

--- a/frontend/src/constants/slash_commands.tsx
+++ b/frontend/src/constants/slash_commands.tsx
@@ -1,0 +1,35 @@
+export enum SlashCommandAvailability {
+  AnyMessage = "ANY_MESSAGE",
+  FollowUpOnly = "FOLLOW_UP_ONLY",
+}
+
+export type SlashCommand = {
+  name: string;
+  description: string;
+  availability: SlashCommandAvailability;
+};
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  {
+    name: "canvas",
+    description: "Generate canvas for the conversation",
+    availability: SlashCommandAvailability.FollowUpOnly,
+  },
+];
+
+export const SLASH_COMMANDS_FOR_FIRST_MESSAGE: SlashCommand[] =
+  SLASH_COMMANDS.filter(
+    (command) => command.availability === SlashCommandAvailability.AnyMessage,
+  );
+
+export const findMatchingSlashCommands = (
+  availableCommands: SlashCommand[],
+  query: string,
+): SlashCommand[] => {
+  const normalizedQuery = query.toLowerCase();
+  return availableCommands.filter(
+    (command) =>
+      command.name.toLowerCase().includes(normalizedQuery) ||
+      command.description.toLowerCase().includes(normalizedQuery),
+  );
+};


### PR DESCRIPTION
Slash commands shipped with no way to find them - no hint, no button, no affordance. Users only found them if they already knew to type `/`.

- Add a `/ Commands` button to the message composer, shown in both new and existing conversations.
- Add a placeholder hint pointing at the `/` key.
- Add a `SlashCommandAvailability` enum so commands that cannot be the first message of a conversation are hidden on the new conversation page. `/canvas` is follow-up only, so the button, chips, hint and `/` trigger are all suppressed there.
- Show available commands as clickable chips alongside suggested questions.
- Move the command registry to `src/constants/slash_commands.tsx` and match on description as well as name.
- Show a "No matching commands" empty state, and stop swallowing Enter when nothing matches.