### PR TITLE
fix(frontend): make canvas stat tooltip text visible

### DIFF
--- a/frontend/src/components/ConversationalAnalytics/CanvasGeneratedCard.tsx
+++ b/frontend/src/components/ConversationalAnalytics/CanvasGeneratedCard.tsx
@@ -6,7 +6,6 @@ import {
   Badge,
   Icon,
   ToolTip,
-  Text,
 } from "src/components/design-system";
 import type { IconType } from "src/components/design-system/datatypes";
 import { APP_ROUTES } from "src/constants/app_routes";
@@ -20,7 +19,7 @@ type CanvasStatProps = {
 
 function CanvasStat({ iconType, count, tooltipText }: CanvasStatProps) {
   return (
-    <ToolTip messageElement={<Text>{tooltipText}</Text>} tooltipSide="top">
+    <ToolTip messageElement={tooltipText} tooltipSide="top">
       <Flex gap="xs" alignItems="center">
         <Icon type={iconType} color="grey" />
         <Badge variant="subtle">{count}</Badge>

--- a/frontend/src/components/Home/components/CanvasStatItem.tsx
+++ b/frontend/src/components/Home/components/CanvasStatItem.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { Flex, Badge, Icon, ToolTip, Text } from "src/components/design-system";
+import { Flex, Badge, Icon, ToolTip } from "src/components/design-system";
 import { IconType } from "src/components/design-system/datatypes";
 
 type CanvasStatItemProps = {
@@ -14,7 +14,7 @@ function CanvasStatItemComponent({
   tooltipText,
 }: CanvasStatItemProps) {
   return (
-    <ToolTip messageElement={<Text>{tooltipText}</Text>} tooltipSide="top">
+    <ToolTip messageElement={tooltipText} tooltipSide="top">
       <Flex gap="xs" alignItems="center">
         <Icon type={iconType} color="grey" />
         <Badge variant="subtle">{count}</Badge>


### PR DESCRIPTION
- Fix canvas stat tooltips rendering as an empty dark box on the home page and the canvas generated card.
- `Text` default color matches the tooltip background, so pass the label string directly and let the tooltip styles apply.