### PR TITLE
fix(backend): store agent-planned pie charts

### DIFF
--- a/backend/src/ai/canvas_generation_agent/system_prompt.rs
+++ b/backend/src/ai/canvas_generation_agent/system_prompt.rs
@@ -44,12 +44,32 @@ Rules when extending an existing canvas:
 When creating a NEW canvas, every entry must be `create`, you must return at least one, and 3-8 focused cells is a good size. Reuse and adapt the SQL already produced in the conversation.
 
 CHART SPEC (for any `create` or `update` that sets `chart`):
-- `chart_type` must be one of: BAR, LINE, PIE, METRIC.
-- BAR and LINE REQUIRE `x_axis` plus `series`, a list of 1 to 6 entries, each with a `column` and optionally its own `aggregate_function` and a `label` for the legend. PIE REQUIRES both `category` and `value` — `category` is the slice label, `value` is the slice size, and PIE uses neither `x_axis` nor `series`. METRIC needs none of them and renders the first value of the first row.
-- Setting only one of the required pair is the most common mistake. A chart missing either of its required fields is discarded and the cell is created without a chart, so fill in both.
-- Add a second series ONLY when the columns share a unit AND a comparable scale, e.g. revenue vs profit. Never combine different units or wildly different magnitudes — the smaller series flattens onto the axis and reads as a bug. Never use the same column twice in one chart. Default to ONE series when unsure.
-- All axis, series and category/value names MUST be column aliases produced by that cell's SQL.
-- An aggregate function is one of: MAX, MIN, SUM, COUNT, AVG. It is applied when grouping rows by `x_axis` (or `category`), so when the SQL already returns one row per group use MAX. For BAR and LINE, EVERY entry in `series` MUST set its own `aggregate_function` — there is no chart-level default, and a series without one discards the whole chart. For PIE, set `aggregate_function` on the chart.
+
+`chart_type` is one of BAR, LINE, PIE, METRIC. The settings of that type go in the object named after it — `axis` for BAR and LINE, `pie` for PIE, `metric` for METRIC. Fill in the one that matches `chart_type` and leave the other two null.
+
+- BAR compares categories. LINE shows a trend over an ordered or temporal x-axis. PIE shows shares of a whole, at most 10 slices. METRIC renders the first value of the first row as one number and needs no columns.
+- Every column name you write MUST be a column alias produced by that cell's SQL.
+- An aggregate function is one of MAX, MIN, SUM, COUNT, AVG. It is applied when grouping rows by the x-axis or the pie category, so when the SQL already returns one row per group use MAX.
+
+`axis` — BAR and LINE:
+- `x_axis` (required): the column along the x-axis.
+- `series` (required): 1 to 6 entries, each with a `column`, its own `aggregate_function`, and an optional `label` for the legend.
+  Add a second series ONLY when the columns share a unit AND a comparable scale, e.g. revenue vs profit. Never combine different units or wildly different magnitudes — the smaller series flattens onto the axis and reads as a bug. Never use the same column twice in one chart. Default to ONE series when unsure.
+- `sort_by_series_column` and `sort_order` (NONE, ASC, DESC): sort by one of the series. The column MUST be one of your `series` columns. Rankings — top, worst, biggest — read best sorted DESC. Leave a time series unsorted so it stays chronological.
+- `orientation` (HORIZONTAL, VERTICAL): this names the AXIS LAYOUT, not the direction the bars run, so it is the reverse of what the two words suggest. Ignore what they sound like and choose by the picture you want:
+  - HORIZONTAL, the default, puts the categories along the x-axis and grows the bars UPWARD. This is the ordinary column chart, and it is what most people mean by a "vertical bar chart".
+  - VERTICAL puts the categories down the y-axis and runs the bars SIDEWAYS to the right. This is what most people mean by a "horizontal bar chart".
+  Pick VERTICAL on a BAR whose category labels are long or numerous, so each label gets its own line and they stop colliding. Keep LINE on HORIZONTAL so the sequence reads left to right.
+- `bar_layout` (GROUPED, STACKED): BAR only. STACKED when the series are parts of one total, GROUPED to compare them side by side.
+- `show_dots` (SHOW, HIDE): LINE only. HIDE when the line has many points.
+- `x_axis_title` and `y_axis_title`: short axis labels. Both name the axis ON SCREEN, so under VERTICAL `x_axis_title` labels the measure and `y_axis_title` labels the categories. Set them when the column alias alone does not read as a label.
+- `x_axis_tick_show`, `y_axis_tick_show`, `axis_minor_tick_show` (SHOW, HIDE): these follow the axis on screen too. HIDE the ticks on whichever axis carries the categories — x under HORIZONTAL, y under VERTICAL — when they are long identifiers that would collide.
+
+`pie` — PIE: `category` (the slice label), `value` (the slice size) and `aggregate_function`. All three are required.
+
+`metric` — METRIC: `format` (DEFAULT, PERCENTAGE, CURRENCY), `decimal_precision`, and `suffix`, a short unit shown after the value that only applies to DEFAULT format.
+
+Every optional setting falls back to a sensible default, so set one only when it makes that chart better.
 
 DASHBOARD LAYOUT. Charts you add are appended to the canvas's dashboard, below whatever is already on it, on a 12-column grid where one row is 100px tall. Set `grid_width` (4-12 columns) and `grid_height` (3-6 rows) per chart. The charts you add are packed left to right in the order you list them and wrap to the next row when they no longer fit, so choose widths that add up to exactly 12 per row and avoid leaving gaps.
 

--- a/backend/src/ai/dto.rs
+++ b/backend/src/ai/dto.rs
@@ -534,20 +534,46 @@ impl Event {
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct AiChartSeries {
     pub column: String,
-    pub aggregate_function: Option<crate::cell::constants::AggregateFunction>,
+    pub aggregate_function: crate::cell::constants::AggregateFunction,
     pub label: Option<String>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct AiAxisChart {
+    pub x_axis: String,
+    pub series: Vec<AiChartSeries>,
+    pub x_axis_title: Option<String>,
+    pub y_axis_title: Option<String>,
+    pub sort_by_series_column: Option<String>,
+    pub sort_order: Option<crate::cell::constants::SortOrder>,
+    pub orientation: Option<crate::cell::constants::ChartOrientation>,
+    pub bar_layout: Option<crate::cell::constants::BarLayout>,
+    pub show_dots: Option<crate::cell::constants::LineDotShow>,
+    pub x_axis_tick_show: Option<crate::cell::constants::AxisTickShow>,
+    pub y_axis_tick_show: Option<crate::cell::constants::AxisTickShow>,
+    pub axis_minor_tick_show: Option<crate::cell::constants::AxisMinorTickShow>,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct AiPieChart {
+    pub category: String,
+    pub value: String,
+    pub aggregate_function: crate::cell::constants::AggregateFunction,
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+pub struct AiMetricChart {
+    pub format: Option<crate::cell::constants::MetricFormat>,
+    pub decimal_precision: Option<i32>,
+    pub suffix: Option<String>,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct CanvasPlanChart {
     pub chart_type: crate::cell::constants::ChartType,
-    pub x_axis: Option<String>,
-    pub y_axis: Option<String>,
-    pub series: Option<Vec<AiChartSeries>>,
-    pub category: Option<String>,
-    pub value: Option<String>,
-    /// PIE only — BAR and LINE carry an aggregate function per series.
-    pub aggregate_function: Option<crate::cell::constants::AggregateFunction>,
+    pub axis: Option<AiAxisChart>,
+    pub pie: Option<AiPieChart>,
+    pub metric: Option<AiMetricChart>,
     pub grid_width: Option<i32>,
     pub grid_height: Option<i32>,
 }
@@ -563,6 +589,16 @@ pub struct PlannedSeries {
 pub struct PlannedAxisChart {
     pub x_axis: String,
     pub series: Vec<PlannedSeries>,
+    pub x_axis_title: Option<String>,
+    pub y_axis_title: Option<String>,
+    pub sort_by_series_column: Option<String>,
+    pub sort_order: crate::cell::constants::SortOrder,
+    pub orientation: crate::cell::constants::ChartOrientation,
+    pub bar_layout: crate::cell::constants::BarLayout,
+    pub show_dots: crate::cell::constants::LineDotShow,
+    pub x_axis_tick_show: crate::cell::constants::AxisTickShow,
+    pub y_axis_tick_show: crate::cell::constants::AxisTickShow,
+    pub axis_minor_tick_show: crate::cell::constants::AxisMinorTickShow,
 }
 
 #[derive(Clone, Debug)]
@@ -573,11 +609,18 @@ pub struct PlannedPieChart {
 }
 
 #[derive(Clone, Debug)]
+pub struct PlannedMetricChart {
+    pub format: crate::cell::constants::MetricFormat,
+    pub decimal_precision: u32,
+    pub suffix: Option<String>,
+}
+
+#[derive(Clone, Debug)]
 pub enum PlannedChartSpec {
     Bar(PlannedAxisChart),
     Line(PlannedAxisChart),
     Pie(PlannedPieChart),
-    Metric,
+    Metric(PlannedMetricChart),
 }
 
 #[derive(Clone, Debug)]
@@ -598,51 +641,122 @@ impl PlannedChart {
 }
 
 impl CanvasPlanChart {
-    fn planned_axis_chart(&self) -> Option<PlannedAxisChart> {
-        let x_axis = non_empty(&self.x_axis).or_else(|| non_empty(&self.category))?;
+    fn planned_axis_chart(&self) -> anyhow::Result<PlannedAxisChart> {
+        use crate::cell::constants::{
+            DEFAULT_AXIS_MINOR_TICK_SHOW, DEFAULT_AXIS_TICK_SHOW, DEFAULT_BAR_LAYOUT,
+            DEFAULT_CHART_ORIENTATION, DEFAULT_CHART_SORT_ORDER, DEFAULT_LINE_DOT_SHOW,
+        };
+
+        let axis = self.axis.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} chart is missing its `axis` settings",
+                self.chart_type.as_str()
+            )
+        })?;
+        let x_axis = non_blank(&axis.x_axis).ok_or_else(|| {
+            anyhow::anyhow!("{} chart has a blank x_axis", self.chart_type.as_str())
+        })?;
 
         let mut seen = std::collections::HashSet::new();
-        let mut series: Vec<PlannedSeries> = self
+        let mut series: Vec<PlannedSeries> = axis
             .series
-            .clone()
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|entry| !entry.column.trim().is_empty())
-            .filter(|entry| seen.insert(entry.column.clone()))
-            .map(|entry| {
-                Some(PlannedSeries {
-                    column: entry.column,
-                    aggregate_function: entry.aggregate_function?,
-                    label: entry.label,
+            .iter()
+            .filter_map(|entry| {
+                let column = non_blank(&entry.column)?;
+                seen.insert(column.clone()).then(|| PlannedSeries {
+                    column,
+                    aggregate_function: entry.aggregate_function.clone(),
+                    label: non_empty(&entry.label),
                 })
             })
-            .collect::<Option<Vec<_>>>()?;
+            .collect();
         if series.is_empty() {
-            return None;
+            anyhow::bail!("{} chart has no series", self.chart_type.as_str());
         }
         series.truncate(crate::cell::constants::MAX_CHART_SERIES);
-        Some(PlannedAxisChart { x_axis, series })
-    }
 
-    fn planned_pie_chart(&self) -> Option<PlannedPieChart> {
-        Some(PlannedPieChart {
-            category: non_empty(&self.category).or_else(|| non_empty(&self.x_axis))?,
-            value: non_empty(&self.value).or_else(|| non_empty(&self.y_axis))?,
-            aggregate_function: self.aggregate_function.clone()?,
+        let sort_by_series_column = non_empty(&axis.sort_by_series_column);
+        if let Some(column) = &sort_by_series_column {
+            if !series.iter().any(|entry| &entry.column == column) {
+                anyhow::bail!(
+                    "{} chart sorts by {:?}, which is not one of its series",
+                    self.chart_type.as_str(),
+                    column
+                );
+            }
+        }
+
+        Ok(PlannedAxisChart {
+            x_axis,
+            series,
+            x_axis_title: non_empty(&axis.x_axis_title),
+            y_axis_title: non_empty(&axis.y_axis_title),
+            sort_by_series_column,
+            sort_order: axis.sort_order.clone().unwrap_or(DEFAULT_CHART_SORT_ORDER),
+            orientation: axis
+                .orientation
+                .clone()
+                .unwrap_or(DEFAULT_CHART_ORIENTATION),
+            bar_layout: axis.bar_layout.clone().unwrap_or(DEFAULT_BAR_LAYOUT),
+            show_dots: axis.show_dots.clone().unwrap_or(DEFAULT_LINE_DOT_SHOW),
+            x_axis_tick_show: axis
+                .x_axis_tick_show
+                .clone()
+                .unwrap_or(DEFAULT_AXIS_TICK_SHOW),
+            y_axis_tick_show: axis
+                .y_axis_tick_show
+                .clone()
+                .unwrap_or(DEFAULT_AXIS_TICK_SHOW),
+            axis_minor_tick_show: axis
+                .axis_minor_tick_show
+                .clone()
+                .unwrap_or(DEFAULT_AXIS_MINOR_TICK_SHOW),
         })
     }
 
-    /// Accepts axis/category as synonyms, since agents mix the two vocabularies.
-    fn planned(&self) -> Option<PlannedChart> {
+    fn planned_pie_chart(&self) -> anyhow::Result<PlannedPieChart> {
+        let pie = self
+            .pie
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("PIE chart is missing its `pie` settings"))?;
+        Ok(PlannedPieChart {
+            category: non_blank(&pie.category)
+                .ok_or_else(|| anyhow::anyhow!("PIE chart has a blank category"))?,
+            value: non_blank(&pie.value)
+                .ok_or_else(|| anyhow::anyhow!("PIE chart has a blank value"))?,
+            aggregate_function: pie.aggregate_function.clone(),
+        })
+    }
+
+    fn planned_metric_chart(&self) -> anyhow::Result<PlannedMetricChart> {
+        use crate::cell::constants::{DEFAULT_METRIC_DECIMAL_PRECISION, DEFAULT_METRIC_FORMAT};
+
+        let metric = self.metric.as_ref();
+        let decimal_precision = match metric.and_then(|settings| settings.decimal_precision) {
+            Some(precision) => u32::try_from(precision).map_err(|_| {
+                anyhow::anyhow!("METRIC chart has a negative decimal_precision of {precision}")
+            })?,
+            None => DEFAULT_METRIC_DECIMAL_PRECISION,
+        };
+        Ok(PlannedMetricChart {
+            format: metric
+                .and_then(|settings| settings.format.clone())
+                .unwrap_or(DEFAULT_METRIC_FORMAT),
+            decimal_precision,
+            suffix: metric.and_then(|settings| non_empty(&settings.suffix)),
+        })
+    }
+
+    fn planned(&self) -> anyhow::Result<PlannedChart> {
         use crate::cell::constants::ChartType;
 
         let spec = match self.chart_type {
             ChartType::Bar => PlannedChartSpec::Bar(self.planned_axis_chart()?),
             ChartType::Line => PlannedChartSpec::Line(self.planned_axis_chart()?),
             ChartType::Pie => PlannedChartSpec::Pie(self.planned_pie_chart()?),
-            ChartType::Metric => PlannedChartSpec::Metric,
+            ChartType::Metric => PlannedChartSpec::Metric(self.planned_metric_chart()?),
         };
-        Some(PlannedChart {
+        Ok(PlannedChart {
             spec,
             grid_width: self.grid_width,
             grid_height: self.grid_height,
@@ -650,17 +764,17 @@ impl CanvasPlanChart {
     }
 }
 
-fn resolve_chart(chart: Option<&CanvasPlanChart>, title: &Option<String>) -> Option<PlannedChart> {
-    let chart = chart?;
-    let planned = chart.planned();
-    if planned.is_none() {
-        tracing::warn!(
-            "canvas plan: dropped {} chart for {:?} because its axis, series or category fields were missing",
-            chart.chart_type.as_str(),
-            title.as_deref().unwrap_or("<untitled>")
-        );
-    }
-    planned
+fn resolve_chart(
+    chart: Option<&CanvasPlanChart>,
+    title: &Option<String>,
+) -> anyhow::Result<Option<PlannedChart>> {
+    let Some(chart) = chart else {
+        return Ok(None);
+    };
+    chart
+        .planned()
+        .map(Some)
+        .map_err(|e| anyhow::anyhow!("cell {:?}: {e}", title.as_deref().unwrap_or("<untitled>")))
 }
 
 fn to_grid_units(value: Option<i32>) -> Option<u16> {
@@ -731,9 +845,13 @@ fn to_zero_based(index: Option<i32>, len: usize) -> Option<usize> {
     (index < len).then_some(index)
 }
 
-fn non_empty(value: &Option<String>) -> Option<String> {
-    let trimmed = value.as_deref()?.trim();
+fn non_blank(value: &str) -> Option<String> {
+    let trimmed = value.trim();
     (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn non_empty(value: &Option<String>) -> Option<String> {
+    non_blank(value.as_deref()?)
 }
 
 fn normalize_sql(sql: &str) -> String {
@@ -748,7 +866,7 @@ impl CanvasPlan {
         to_zero_based(self.target_canvas_index, candidates.len()).map(|i| candidates[i].id)
     }
 
-    pub fn resolve_ops(&self, target: Option<&CanvasCandidate>) -> Vec<CanvasOp> {
+    pub fn resolve_ops(&self, target: Option<&CanvasCandidate>) -> anyhow::Result<Vec<CanvasOp>> {
         let cell_count = target.map(|c| c.cells.len()).unwrap_or(0);
         let mut present: std::collections::HashSet<String> = target
             .map(|c| {
@@ -761,7 +879,7 @@ impl CanvasPlan {
 
         let mut ops = Vec::new();
         for cell in self.cells.iter() {
-            let Some(op) = Self::resolve_op(cell, cell_count) else {
+            let Some(op) = Self::resolve_op(cell, cell_count)? else {
                 continue;
             };
             match &op {
@@ -783,23 +901,30 @@ impl CanvasPlan {
             }
             ops.push(op);
         }
-        ops
+        Ok(ops)
     }
 
-    fn resolve_op(cell: &CanvasPlanCell, cell_count: usize) -> Option<CanvasOp> {
-        match cell.action {
-            CanvasCellAction::Create => Some(CanvasOp::Create {
-                title: non_empty(&cell.title),
-                sql: non_empty(&cell.sql)?,
-                chart: resolve_chart(cell.chart.as_ref(), &cell.title),
-            }),
+    fn resolve_op(cell: &CanvasPlanCell, cell_count: usize) -> anyhow::Result<Option<CanvasOp>> {
+        Ok(match cell.action {
+            CanvasCellAction::Create => {
+                let Some(sql) = non_empty(&cell.sql) else {
+                    return Ok(None);
+                };
+                Some(CanvasOp::Create {
+                    title: non_empty(&cell.title),
+                    sql,
+                    chart: resolve_chart(cell.chart.as_ref(), &cell.title)?,
+                })
+            }
             CanvasCellAction::Update => {
-                let index = to_zero_based(cell.target_cell_index, cell_count)?;
+                let Some(index) = to_zero_based(cell.target_cell_index, cell_count) else {
+                    return Ok(None);
+                };
                 let title = non_empty(&cell.title);
                 let sql = non_empty(&cell.sql);
-                let chart = resolve_chart(cell.chart.as_ref(), &cell.title);
+                let chart = resolve_chart(cell.chart.as_ref(), &cell.title)?;
                 if title.is_none() && sql.is_none() && chart.is_none() {
-                    return None;
+                    return Ok(None);
                 }
                 Some(CanvasOp::Update {
                     index,
@@ -808,10 +933,9 @@ impl CanvasPlan {
                     chart,
                 })
             }
-            CanvasCellAction::Delete => Some(CanvasOp::Delete {
-                index: to_zero_based(cell.target_cell_index, cell_count)?,
-            }),
-        }
+            CanvasCellAction::Delete => to_zero_based(cell.target_cell_index, cell_count)
+                .map(|index| CanvasOp::Delete { index }),
+        })
     }
 }
 

--- a/backend/src/canvas/service.rs
+++ b/backend/src/canvas/service.rs
@@ -5,10 +5,7 @@ use crate::ai::dto::{
 use crate::canvas::constants::CanvasStatus;
 use crate::canvas::dto;
 use crate::canvas::repository;
-use crate::cell::constants::{
-    AxisMinorTickShow, AxisTickShow, BarLayout, CellType, ChartOrientation, ChartType, MetricFormat,
-    SortOrder,
-};
+use crate::cell::constants::{CellType, ChartType};
 use crate::cell::dto::{
     series_alias, AxisChartContent, ChartContent, ChartSeries, CreateCellDto, MetricChartContent,
     PieChartContent,
@@ -168,29 +165,38 @@ async fn create_canvas_transaction(
 }
 
 fn axis_chart_content(cell_id: Uuid, axis: &PlannedAxisChart) -> AxisChartContent {
+    let series: Vec<ChartSeries> = axis
+        .series
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| ChartSeries {
+            alias: series_alias(&entry.column, &entry.aggregate_function),
+            column: entry.column.clone(),
+            aggregate_function: Some(entry.aggregate_function.clone()),
+            label: entry.label.clone(),
+            color_index: Some(index as u32),
+        })
+        .collect();
+
     AxisChartContent {
         cell_id,
         x_axis: axis.x_axis.clone(),
         x_axis_alias: axis.x_axis.clone(),
-        series: axis
-            .series
-            .iter()
-            .enumerate()
-            .map(|(index, entry)| ChartSeries {
-                alias: series_alias(&entry.column, &entry.aggregate_function),
-                column: entry.column.clone(),
-                aggregate_function: Some(entry.aggregate_function.clone()),
-                label: entry.label.clone(),
-                color_index: Some(index as u32),
-            })
-            .collect(),
-        y_axis_sort_by: None,
-        bar_layout: Some(BarLayout::Grouped),
-        orientation: Some(ChartOrientation::Horizontal),
-        y_axis_sort_order: Some(SortOrder::None),
-        x_axis_tick_show: Some(AxisTickShow::Show),
-        y_axis_tick_show: Some(AxisTickShow::Show),
-        axis_minor_tick_show: Some(AxisMinorTickShow::Show),
+        x_axis_title: axis.x_axis_title.clone(),
+        y_axis_title: axis.y_axis_title.clone(),
+        y_axis_sort_by: axis
+            .sort_by_series_column
+            .as_ref()
+            .and_then(|column| series.iter().find(|entry| &entry.column == column))
+            .map(|entry| entry.alias.clone()),
+        series,
+        bar_layout: Some(axis.bar_layout.clone()),
+        orientation: Some(axis.orientation.clone()),
+        y_axis_sort_order: Some(axis.sort_order.clone()),
+        x_axis_tick_show: Some(axis.x_axis_tick_show.clone()),
+        y_axis_tick_show: Some(axis.y_axis_tick_show.clone()),
+        axis_minor_tick_show: Some(axis.axis_minor_tick_show.clone()),
+        show_dots: Some(axis.show_dots.clone()),
     }
 }
 
@@ -204,11 +210,11 @@ fn chart_content_json(cell_id: Uuid, chart: &PlannedChart) -> Result<String, sea
             value: pie.value.clone(),
             aggregate_function: Some(pie.aggregate_function.as_str().to_string()),
         }),
-        PlannedChartSpec::Metric => ChartContent::Metric(MetricChartContent {
+        PlannedChartSpec::Metric(metric) => ChartContent::Metric(MetricChartContent {
             cell_id,
-            decimal_precision: Some(2),
-            suffix: None,
-            format: Some(MetricFormat::Default),
+            decimal_precision: Some(metric.decimal_precision),
+            suffix: metric.suffix.clone(),
+            format: Some(metric.format.clone()),
         }),
     };
 
@@ -350,8 +356,7 @@ pub async fn apply_canvas_plan(
     }
     let name = non_blank(&plan.name).unwrap_or_else(|| canvas.name.clone());
     let description = non_blank(&plan.description).or_else(|| canvas.description.clone());
-    let canvas =
-        repository::update_canvas_transaction(&txn, canvas, name, description).await?;
+    let canvas = repository::update_canvas_transaction(&txn, canvas, name, description).await?;
 
     txn.commit().await?;
 

--- a/backend/src/cell/constants.rs
+++ b/backend/src/cell/constants.rs
@@ -5,6 +5,15 @@ pub const MAX_CELLS_PER_NOTEBOOK: usize = 60;
 pub const MAX_CHART_SERIES: usize = 6;
 pub const MAX_IDENTIFIER_LEN: usize = 128;
 
+pub const DEFAULT_CHART_SORT_ORDER: SortOrder = SortOrder::None;
+pub const DEFAULT_CHART_ORIENTATION: ChartOrientation = ChartOrientation::Horizontal;
+pub const DEFAULT_BAR_LAYOUT: BarLayout = BarLayout::Grouped;
+pub const DEFAULT_LINE_DOT_SHOW: LineDotShow = LineDotShow::Show;
+pub const DEFAULT_AXIS_TICK_SHOW: AxisTickShow = AxisTickShow::Show;
+pub const DEFAULT_AXIS_MINOR_TICK_SHOW: AxisMinorTickShow = AxisMinorTickShow::Show;
+pub const DEFAULT_METRIC_FORMAT: MetricFormat = MetricFormat::Default;
+pub const DEFAULT_METRIC_DECIMAL_PRECISION: u32 = 2;
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum CellType {
@@ -66,21 +75,21 @@ impl std::fmt::Display for CellStatus {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, schemars::JsonSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ChartOrientation {
     Horizontal,
     Vertical,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, schemars::JsonSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum BarLayout {
     Grouped,
     Stacked,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, schemars::JsonSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum SortOrder {
     None,
@@ -98,21 +107,28 @@ impl SortOrder {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, schemars::JsonSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum AxisTickShow {
     Show,
     Hide,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, schemars::JsonSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum AxisMinorTickShow {
     Show,
     Hide,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, schemars::JsonSchema)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum LineDotShow {
+    Show,
+    Hide,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, schemars::JsonSchema)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum MetricFormat {
     Default,

--- a/backend/src/cell/dto.rs
+++ b/backend/src/cell/dto.rs
@@ -7,6 +7,7 @@ use crate::cell::constants::CellStatus;
 use crate::cell::constants::CellType;
 use crate::cell::constants::ChartOrientation;
 use crate::cell::constants::ChartType;
+use crate::cell::constants::LineDotShow;
 use crate::cell::constants::MetricFormat;
 use crate::cell::constants::SortOrder;
 use crate::common::errors::ExecuteChartError;
@@ -105,6 +106,8 @@ pub struct AxisChartContent {
     pub x_axis_alias: String,
     #[serde(default)]
     pub series: Vec<ChartSeries>,
+    pub x_axis_title: Option<String>,
+    pub y_axis_title: Option<String>,
     pub y_axis_sort_by: Option<String>,
     #[serde(default)]
     pub bar_layout: Option<BarLayout>,
@@ -113,6 +116,7 @@ pub struct AxisChartContent {
     pub x_axis_tick_show: Option<AxisTickShow>,
     pub y_axis_tick_show: Option<AxisTickShow>,
     pub axis_minor_tick_show: Option<AxisMinorTickShow>,
+    pub show_dots: Option<LineDotShow>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/backend/src/conversational_analytics/conversation/canvas.rs
+++ b/backend/src/conversational_analytics/conversation/canvas.rs
@@ -25,7 +25,7 @@ pub async fn generate(
     let target_canvas_id = plan.resolve_target_canvas(&candidates);
     let target =
         target_canvas_id.and_then(|id| candidates.iter().find(|candidate| candidate.id == id));
-    let ops = plan.resolve_ops(target);
+    let ops = plan.resolve_ops(target)?;
     if ops.is_empty() && target_canvas_id.is_none() {
         anyhow::bail!("the canvas plan contained no usable cells");
     }


### PR DESCRIPTION
- Group each chart type's settings into its own object (`axis`, `pie`, `metric`) so the fields a type requires are required and non-nullable in the agent's JSON schema. PIE's `aggregate_function` was optional in the schema but hard-required in code, so a plan omitting it had its chart silently dropped and only the SQL cell was created.
- Fail loudly when a chart still cannot be built, instead of dropping it with a warning log.
- Expose the full chart cell feature set to the canvas agent: sort by series and sort order, orientation, bar layout, show dots, axis titles, tick visibility, and metric format, decimal precision and suffix. These were hardcoded in `axis_chart_content`.
- Add `x_axis_title`, `y_axis_title` and `show_dots` to `AxisChartContent`, which the frontend already read but the backend never wrote.
- Use a signed `decimal_precision` in the agent schema, since an unsigned schemars type emits a `minimum` constraint that Anthropic rejects on integer properties.
- Correct the `orientation` semantics in the canvas agent prompt: the enum names the axis layout, not the bar direction, so it is the reverse of what the words suggest. Axis titles and tick toggles follow the on-screen axis and swap with it.